### PR TITLE
[Fix] Formation data on client side is different from one on server side

### DIFF
--- a/src/main/java/jp/ngt/rtm/entity/train/EntityBogie.java
+++ b/src/main/java/jp/ngt/rtm/entity/train/EntityBogie.java
@@ -3,6 +3,7 @@ package jp.ngt.rtm.entity.train;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import jp.ngt.ngtlib.io.NGTLog;
+import jp.ngt.ngtlib.math.BezierCurve;
 import jp.ngt.ngtlib.math.NGTMath;
 import jp.ngt.ngtlib.math.Vec3;
 import jp.ngt.ngtlib.protection.Lockable;
@@ -279,23 +280,16 @@ public class EntityBogie extends Entity implements Lockable {
             {
             } else//新しいレール上に移動
             {
-                RailMap railMap;
+                this.currentRailObj = coreObj;
                 if (coreObj instanceof TileEntityLargeRailSwitchCore) {
                     TileEntityLargeRailSwitchCore switchObj = (TileEntityLargeRailSwitchCore) coreObj;
-                    railMap = switchObj.getSwitch().getNearestPoint(this).getActiveRailMap(this.worldObj);
+                    this.currentRailMap = switchObj.getSwitch().getNearestPoint(this).getActiveRailMap(this.worldObj);
                 } else {
-                    railMap = coreObj.getRailMap(this);
+                    this.currentRailMap = coreObj.getRailMap(this);
                 }
-
-                if (this.currentRailMap != null && !this.currentRailMap.canConnect(railMap)) {
-                    return true;
-                }
-
-                this.currentRailObj = coreObj;
-                this.currentRailMap = railMap;
-                this.split = (int) (this.currentRailMap.getLength() * (double) SPLIT_VALUE);
+                this.split = (int) (this.currentRailMap.getLength() * (double) BezierCurve.QUANTIZE);
                 this.prevPosIndex = -1;
-                this.onChangeRail(px, py, pz);
+                this.onChangeRail(coreObj);
             }
 
             return true;
@@ -305,9 +299,8 @@ public class EntityBogie extends Entity implements Lockable {
     /**
      * 別レールに移動した際呼び出し
      */
-    protected void onChangeRail(double px, double py, double pz) {
-        TileEntityLargeRailBase railObj = TileEntityLargeRailBase.getRailFromCoordinates(this.worldObj, px, py, pz);
-        this.reverbSound = railObj.isReberbSound();
+    protected void onChangeRail(TileEntityLargeRailCore newRail) {
+        this.reverbSound = newRail.isReberbSound();
         TrainConfig cfg = this.getTrain().getModelSet().getConfig();
         if (!cfg.muteJointSound) {
             this.jointIndex = 0;

--- a/src/main/java/jp/ngt/rtm/entity/train/EntityTrainBase.java
+++ b/src/main/java/jp/ngt/rtm/entity/train/EntityTrainBase.java
@@ -141,6 +141,7 @@ public abstract class EntityTrainBase extends EntityVehicleBase<TrainConfig> imp
             nbt.setLong("FormationId", this.formation.id);
             nbt.setByte("EntryPos", entry.entryId);
             nbt.setByte("EntryDir", entry.dir);
+            nbt.setInteger("FormationSize", this.formation.size());
         }
     }
 
@@ -159,9 +160,14 @@ public abstract class EntityTrainBase extends EntityVehicleBase<TrainConfig> imp
         long id = nbt.getLong("FormationId");
         byte pos = nbt.getByte("EntryPos");
         byte dir = nbt.getByte("EntryDir");
+        int size = nbt.getInteger("FormationSize");
         Formation f0 = FormationManager.getInstance().getFormation(id);
         if (f0 == null) {
-            this.formation = FormationManager.getInstance().createNewFormation(this);
+            if (nbt.hasKey("FormationId")) {
+                this.formation = FormationManager.getInstance().createNewFormation(this, id, pos, dir, size);
+            } else {
+                this.formation = FormationManager.getInstance().createNewFormation(this);
+            }
         } else {
             this.formation = f0;
             f0.setTrain(this, pos, dir);

--- a/src/main/java/jp/ngt/rtm/entity/train/util/Formation.java
+++ b/src/main/java/jp/ngt/rtm/entity/train/util/Formation.java
@@ -42,6 +42,7 @@ public class Formation {
         long fid = nbt.getLong("FormationId");
         int num = nbt.getInteger("Size");
         Formation formation = new Formation(fid, num);
+        formation.direction = nbt.getByte("Direction");
 
         if (withEntries) {
             NBTTagList tagList = nbt.getTagList("Entries", 10);
@@ -61,6 +62,7 @@ public class Formation {
     public void writeToNBT(NBTTagCompound nbt, boolean withEntries) {
         nbt.setLong("FormationId", this.id);
         nbt.setInteger("Size", this.entries.length);
+        nbt.setByte("Direction", this.direction);
 
         if (withEntries) {
             NBTTagList tagList = new NBTTagList();
@@ -101,9 +103,7 @@ public class Formation {
      */
     public void setTrain(EntityTrainBase par1, int par3, int par5) {
         this.setEntry(new FormationEntry(par1, par3, par5), par3);
-        if (!par1.worldObj.isRemote) {
-            this.sendPacket();
-        }
+        this.sendPacket();
     }
 
     @SideOnly(Side.CLIENT)
@@ -317,8 +317,10 @@ public class Formation {
         return Arrays.stream(this.entries).filter(Objects::nonNull).map(entry -> entry.train).filter(Objects::nonNull).anyMatch(train -> train.getBogie(0) == bogie || train.getBogie(1) == bogie);
     }
 
-    private void sendPacket() {
-        RTMCore.NETWORK_WRAPPER.sendToAll(new PacketFormation(this));
+    public void sendPacket() {
+        if (NGTUtil.isServer()) {
+            RTMCore.NETWORK_WRAPPER.sendToAll(new PacketFormation(this));
+        }
     }
 
     public boolean isFrontCar(EntityTrainBase train) {

--- a/src/main/java/jp/ngt/rtm/entity/train/util/FormationManager.java
+++ b/src/main/java/jp/ngt/rtm/entity/train/util/FormationManager.java
@@ -100,4 +100,10 @@ public final class FormationManager {
         formation.setTrain(par1, 0, 0);
         return formation;
     }
+
+    public Formation createNewFormation(EntityTrainBase par1, long id, byte pos, byte dir, int size) {
+        Formation formation = new Formation(id, size);
+        formation.setTrain(par1, pos, dir);
+        return formation;
+    }
 }

--- a/src/main/java/jp/ngt/rtm/sound/SoundUpdaterTrain.java
+++ b/src/main/java/jp/ngt/rtm/sound/SoundUpdaterTrain.java
@@ -111,7 +111,7 @@ public class SoundUpdaterTrain extends SoundUpdaterVehicle {
 
     public int getNotch() {
         Formation formation = this.theTrain.getFormation();
-        return formation == null ? 0 : formation.getNotch();
+        return formation == null ? this.theTrain.isControlCar() ? this.theTrain.getNotch() : 0 : formation.getNotch();
     }
 
     public byte getState(int id) {


### PR DESCRIPTION
クライアント側に編成データに両数等の情報が無いことがある問題を修正
主にワールドロード時など