### PR TITLE
[Fix] crash when click ItemWithModel

### DIFF
--- a/src/main/java/jp/ngt/rtm/item/ItemWithModel.java
+++ b/src/main/java/jp/ngt/rtm/item/ItemWithModel.java
@@ -119,7 +119,7 @@ public abstract class ItemWithModel extends Item implements IModelSelectorWithTy
 
     public ResourceState getModelState(ItemStack itemStack) {
         ResourceState state = new ResourceState(this);
-        if (itemStack.getTagCompound().hasKey("State")) {
+        if (itemStack.hasTagCompound() && itemStack.getTagCompound().hasKey("State")) {
             state.readFromNBT(itemStack.getTagCompound().getCompoundTag("State"));
         } else {
             NBTTagCompound nbt;


### PR DESCRIPTION

```
java.lang.NullPointerException: Unexpected error
	at jp.ngt.rtm.item.ItemWithModel.getModelState(ItemWithModel.java:122)
	at jp.ngt.rtm.item.ItemWithModel.getResourceState(ItemWithModel.java:117)
	at jp.ngt.rtm.gui.GuiSelectModel.func_73866_w_(GuiSelectModel.java:79)
	at net.minecraft.client.gui.GuiScreen.func_146280_a(GuiScreen.java:255)
	at net.minecraft.client.Minecraft.func_147108_a(Minecraft.java:808)
	at cpw.mods.fml.client.FMLClientHandler.showGuiScreen(FMLClientHandler.java:472)
	at cpw.mods.fml.common.FMLCommonHandler.showGuiScreen(FMLCommonHandler.java:303)
	at cpw.mods.fml.common.network.internal.FMLNetworkHandler.openGui(FMLNetworkHandler.java:94)
	at net.minecraft.entity.player.EntityPlayer.openGui(EntityPlayer.java:2209)
	at jp.ngt.rtm.item.ItemWithModel.func_77659_a(ItemWithModel.java:39)
	at net.minecraft.item.ItemStack.func_77957_a(ItemStack.java:146)
	at net.minecraft.client.multiplayer.PlayerControllerMP.func_78769_a(PlayerControllerMP.java:377)
	at net.minecraft.client.Minecraft.func_147121_ag(Minecraft.java:1475)
	at net.minecraft.client.Minecraft.func_71407_l(Minecraft.java:1953)
	at net.minecraft.client.Minecraft.func_71411_J(Minecraft.java:973)
	at net.minecraft.client.Minecraft.func_99999_d(Minecraft.java:898)
	at net.minecraft.client.main.Main.main(SourceFile:148)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:497)
	at net.minecraft.launchwrapper.Launch.launch(Launch.java:135)
	at net.minecraft.launchwrapper.Launch.main(Launch.java:28)
```