### PR TITLE
[Improve] Send logs of switch type error to players only

### DIFF
--- a/src/main/java/jp/ngt/rtm/rail/BlockMarker.java
+++ b/src/main/java/jp/ngt/rtm/rail/BlockMarker.java
@@ -2,6 +2,7 @@ package jp.ngt.rtm.rail;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import jp.ngt.ngtlib.io.NGTLog;
 import jp.ngt.ngtlib.math.NGTMath;
 import jp.ngt.ngtlib.util.PermissionManager;
 import jp.ngt.rtm.*;
@@ -192,7 +193,7 @@ public class BlockMarker extends BlockContainer {
                     return this.createTurntable(world, list.get(0), list.get(1), prop, makeRail, isCreative);
                 }
                 if (list.size() > 0) {
-                    return this.createRail1(world, x, y, z, list, prop, makeRail, isCreative);
+                    return this.createRail1(world, x, y, z, player, list, prop, makeRail, isCreative);
                 }
             } else if (type == 2) {
                 return this.createRail2(world, x, y, z, prop, makeRail, isCreative);
@@ -244,10 +245,11 @@ public class BlockMarker extends BlockContainer {
      *
      * @param list {x, y, z}
      */
-    private boolean createRail1(World world, int x, int y, int z, List<RailPosition> list, RailProperty prop, boolean makeRail, boolean isCreative) {
+    private boolean createRail1(World world, int x, int y, int z, EntityPlayer player, List<RailPosition> list, RailProperty prop, boolean makeRail, boolean isCreative) {
         RailMaker railMaker = new RailMaker(world, list);
         SwitchType st = railMaker.getSwitch();
         if (st == null) {
+            NGTLog.sendChatMessage(player, "message.rail.switch_type");
             return false;
         }
         RailMapSwitch[] arrayOfRailMapSwitch = st.getAllRailMap();

--- a/src/main/java/jp/ngt/rtm/rail/util/RailMaker.java
+++ b/src/main/java/jp/ngt/rtm/rail/util/RailMaker.java
@@ -1,6 +1,5 @@
 package jp.ngt.rtm.rail.util;
 
-import jp.ngt.ngtlib.io.NGTLog;
 import net.minecraft.world.World;
 
 import java.util.ArrayList;
@@ -60,11 +59,6 @@ public final class RailMaker {
             if (type.init(switchList, normalList)) {
                 return type;
             }
-        }
-
-        if (this.worldObj != null && !this.worldObj.isRemote) {
-            RailPosition rp = this.rpList.get(0);
-            NGTLog.sendChatMessageToAll("message.rail.switch_type", rp.blockX, rp.blockY, rp.blockZ);
         }
 
         return null;


### PR DESCRIPTION
分岐タイプが見つからない際のログをサーバー全体からプレイヤー限定で送信するように改善