### PR TITLE
Fix crash of mctrl

### DIFF
--- a/src/main/java/jp/ngt/ngtlib/math/NGTMath.java
+++ b/src/main/java/jp/ngt/ngtlib/math/NGTMath.java
@@ -231,6 +231,10 @@ public final class NGTMath {
     }
 
     public static int clamp(int value, int min, int max) {
-        return (value < min) ? min : (Math.min(value, max));
+        return Math.min(max, Math.max(min, value));
+    }
+
+    public static byte clamp(byte value, byte min, byte max) {
+        return (byte) NGTMath.clamp((int) value, min, max);
     }
 }

--- a/src/main/java/jp/ngt/rtm/command/CommandMCtrl.java
+++ b/src/main/java/jp/ngt/rtm/command/CommandMCtrl.java
@@ -93,10 +93,12 @@ public class CommandMCtrl extends CommandBase {
     public List<String> addTabCompletionOptions(ICommandSender sender, String[] args) {
         if (args.length <= 2) {
             //入力されている文字列と先頭一致
-            if (args[args.length - 1].length() == 0) {
-                return subCommandsList.get(args.length - 1);
+            int i = args.length - 1;
+            if (args[i].length() == 0) {
+                return subCommandsList.get(i);
+            } else {
+                return subCommandsList.get(i).stream().filter(s -> s.startsWith(args[i])).collect(Collectors.toList());
             }
-            return subCommandsList.get(args.length - 1).stream().filter(s -> s.startsWith(args[0])).collect(Collectors.toList());
         }
         return null;
     }

--- a/src/main/java/jp/ngt/rtm/command/ModelCtrl.java
+++ b/src/main/java/jp/ngt/rtm/command/ModelCtrl.java
@@ -9,20 +9,16 @@ import net.minecraft.command.ICommandSender;
 
 public enum ModelCtrl {
     NOTCH(
-            (s) -> {
-                return s.equals("notch");
-            },
-            (obj) -> obj instanceof EntityTrainBase,
+            s -> s.equals("notch"),
+            obj -> obj instanceof EntityTrainBase,
             (target, player, order, value) -> {
                 int notch = Integer.parseInt(value);
                 return ((EntityTrainBase) target).setNotch(notch);
             },
             "mctrl <train> notch <-8 ~ 5>"),
     DIR(
-            (s) -> {
-                return s.equals("dir");
-            },
-            (obj) -> obj instanceof EntityTrainBase,
+            s -> s.equals("dir"),
+            obj -> obj instanceof EntityTrainBase,
             (target, player, order, value) -> {
                 int dir = Integer.parseInt(value);
                 ((EntityTrainBase) target).setTrainDirection(dir);
@@ -30,10 +26,8 @@ public enum ModelCtrl {
             },
             "mctrl <train> dir <0 or 1>"),
     DATA_MAP(
-            (s) -> {
-                return s.startsWith("dm:");
-            },
-            (obj) -> obj instanceof IModelSelector,
+            s -> s.startsWith("dm:"),
+            obj -> obj instanceof IModelSelector,
             (target, player, order, value) -> {
                 String dataName = order.replace("dm:", "");
                 if (!((IModelSelector) target).getResourceState().getDataMap().set(dataName, value, 3)) {
@@ -44,10 +38,8 @@ public enum ModelCtrl {
             },
             "mctrl <?> dm:<data name> <(type)value>"),
     VEHICLE_STATE(
-            (s) -> {
-                return s.startsWith("state:");
-            },
-            (obj) -> obj instanceof EntityTrainBase,
+            s -> s.startsWith("state:"),
+            obj -> obj instanceof EntityTrainBase,
             (target, player, order, value) -> {
                 String dataName = order.replace("state:", "");
                 try {
@@ -123,7 +115,7 @@ public enum ModelCtrl {
 //                return true;
 //            },
 //            "mctrl <artillery> fire <number of bullet>"),
-    NO_FUNC((s) -> false, (obj) -> false, (target, player, order, value) -> false, "");
+    NO_FUNC(s -> false, obj -> false, (target, player, order, value) -> false, "");
 
     public final CommandMatcher matcher;
     public final TargetFilter filter;


### PR DESCRIPTION
MCtrlのタブ補完が機能していない問題を修正。
MCtrlの引数に範囲外の値を入力した際にクラッシュし、ワールドを読み込めなくなる問題を修正。
closes #217 
