### PR TITLE
Pick offset

### DIFF
--- a/src/main/java/jp/ngt/rtm/block/BlockLinePole.java
+++ b/src/main/java/jp/ngt/rtm/block/BlockLinePole.java
@@ -2,18 +2,23 @@ package jp.ngt.rtm.block;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import jp.ngt.ngtlib.block.TileEntityPlaceable;
 import jp.ngt.rtm.RTMBlock;
 import jp.ngt.rtm.RTMItem;
 import jp.ngt.rtm.block.tileentity.TileEntityPole;
+import jp.ngt.rtm.item.ItemWithModel;
 import net.minecraft.block.Block;
 import net.minecraft.block.material.MapColor;
 import net.minecraft.block.material.Material;
 import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.MovingObjectPosition;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
+import org.lwjgl.input.Keyboard;
 
 import java.util.Random;
 
@@ -100,5 +105,17 @@ public class BlockLinePole extends BlockOrnamentBase {
     public static boolean isConnected(IBlockAccess world, int x, int y, int z, boolean connectOther) {
         Block block = world.getBlock(x, y, z);
         return block == RTMBlock.linePole || block == RTMBlock.framework || block == RTMBlock.signal || (connectOther && block.isOpaqueCube());
+    }
+
+    @Override
+    public ItemStack getPickBlock(MovingObjectPosition target, World world, int x, int y, int z, EntityPlayer player) {
+        ItemStack itemStack = super.getPickBlock(target, world, x, y, z, player);
+        TileEntity tileEntity = world.getTileEntity(x, y, z);
+
+        if (itemStack != null && tileEntity instanceof TileEntityPlaceable && Keyboard.isKeyDown(Keyboard.KEY_LCONTROL)) {
+            ItemWithModel.copyOffsetToItemStack((TileEntityPlaceable) tileEntity, itemStack);
+        }
+
+        return itemStack;
     }
 }

--- a/src/main/java/jp/ngt/rtm/electric/BlockElectricalWiring.java
+++ b/src/main/java/jp/ngt/rtm/electric/BlockElectricalWiring.java
@@ -1,5 +1,6 @@
 package jp.ngt.rtm.electric;
 
+import jp.ngt.ngtlib.block.TileEntityPlaceable;
 import jp.ngt.ngtlib.util.NGTUtil;
 import jp.ngt.rtm.RTMCore;
 import jp.ngt.rtm.RTMItem;
@@ -13,6 +14,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.MovingObjectPosition;
 import net.minecraft.world.World;
+import org.lwjgl.input.Keyboard;
 
 public abstract class BlockElectricalWiring extends BlockContainer implements IBlockConnective {
     protected BlockElectricalWiring(Material material) {
@@ -60,6 +62,9 @@ public abstract class BlockElectricalWiring extends BlockContainer implements IB
         TileEntity tileEntity = world.getTileEntity(x, y, z);
         if (tileEntity instanceof TileEntityConnectorBase) {
             ((ItemWithModel) RTMItem.installedObject).setModelName(itemStack, ((TileEntityConnectorBase) tileEntity).getModelName());
+            if (Keyboard.isKeyDown(Keyboard.KEY_LCONTROL)) {
+                ItemWithModel.copyOffsetToItemStack((TileEntityPlaceable) tileEntity, itemStack);
+            }
         }
         return itemStack;
     }

--- a/src/main/java/jp/ngt/rtm/item/ItemInstalledObject.java
+++ b/src/main/java/jp/ngt/rtm/item/ItemInstalledObject.java
@@ -157,6 +157,7 @@ public class ItemInstalledObject extends ItemWithModel {
                 block = RTMBlock.linePole;
                 world.setBlock(par4, par5, par6, block, 0, 3);
                 TileEntityPole tile = (TileEntityPole) world.getTileEntity(par4, par5, par6);
+                ItemWithModel.applyOffsetToTileEntity(itemStack, tile);
                 tile.setModelName(this.getModelName(itemStack));
                 tile.getResourceState().readFromNBT(this.getModelState(itemStack).writeToNBT());
             } else if (type == IstlObjType.POINT) {
@@ -222,6 +223,7 @@ public class ItemInstalledObject extends ItemWithModel {
             } else if (type == IstlObjType.INSULATOR) {
                 world.setBlock(par4, par5, par6, RTMBlock.insulator, par7, 2);
                 TileEntityInsulator tile = (TileEntityInsulator) world.getTileEntity(par4, par5, par6);
+                ItemWithModel.applyOffsetToTileEntity(itemStack, tile);
                 tile.setModelName(this.getModelName(itemStack));
                 tile.getResourceState().readFromNBT(this.getModelState(itemStack).writeToNBT());
                 block = RTMBlock.insulator;
@@ -233,6 +235,7 @@ public class ItemInstalledObject extends ItemWithModel {
                     }
                     world.setBlock(par4, par5, par6, RTMBlock.connector, par7, 2);
                     TileEntityConnector tile = (TileEntityConnector) world.getTileEntity(par4, par5, par6);
+                    ItemWithModel.applyOffsetToTileEntity(itemStack, tile);
                     tile.setModelName(this.getModelName(itemStack));
                     tile.getResourceState().readFromNBT(this.getModelState(itemStack).writeToNBT());
                     tile.setConnectionTo(x, y, z, ConnectionType.DIRECT, "");

--- a/src/main/java/jp/ngt/rtm/item/ItemWithModel.java
+++ b/src/main/java/jp/ngt/rtm/item/ItemWithModel.java
@@ -2,6 +2,7 @@ package jp.ngt.rtm.item;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import jp.ngt.ngtlib.block.TileEntityPlaceable;
 import jp.ngt.ngtlib.util.NGTUtil;
 import jp.ngt.rtm.RTMCore;
 import jp.ngt.rtm.modelpack.IModelSelectorWithType;
@@ -139,8 +140,54 @@ public abstract class ItemWithModel extends Item implements IModelSelectorWithTy
             itemStack.setTagCompound(new NBTTagCompound());
         }
         itemStack.getTagCompound().setTag("State", state.writeToNBT());
-        if (this.selectedPlayer != null) {
-            NGTUtil.sendPacketToServer(this.selectedPlayer, this.selectedItem);
+    }
+
+    public static boolean hasOffset(ItemStack itemStack) {
+        return itemStack.hasTagCompound() && itemStack.getTagCompound().hasKey("yaw");
+    }
+
+    private static float[] getOffset(ItemStack itemStack) {
+        if (itemStack.hasTagCompound()) {
+            NBTTagCompound nbt = itemStack.getTagCompound();
+            float offsetX = nbt.getFloat("offsetX");
+            float offsetY = nbt.getFloat("offsetY");
+            float offsetZ = nbt.getFloat("offsetZ");
+            return new float[]{offsetX, offsetY, offsetZ};
+        } else {
+            return new float[3];
         }
+    }
+
+    private static float getRotation(ItemStack itemStack) {
+        return itemStack.hasTagCompound() ? itemStack.getTagCompound().getFloat("yaw") : 0;
+    }
+
+    private static void setOffset(ItemStack itemStack, float offsetX, float offsetY, float offsetZ) {
+        if (!itemStack.hasTagCompound()) {
+            itemStack.setTagCompound(new NBTTagCompound());
+        }
+        NBTTagCompound nbt = itemStack.getTagCompound();
+        nbt.setFloat("offsetX", offsetX);
+        nbt.setFloat("offsetY", offsetY);
+        nbt.setFloat("offsetZ", offsetZ);
+    }
+
+    private static void setRotation(ItemStack itemStack, float rotation) {
+        if (!itemStack.hasTagCompound()) {
+            itemStack.setTagCompound(new NBTTagCompound());
+        }
+        NBTTagCompound nbt = itemStack.getTagCompound();
+        nbt.setFloat("yaw", rotation);
+    }
+
+    public static void applyOffsetToTileEntity(ItemStack itemStack, TileEntityPlaceable tile) {
+        float[] offset = ItemWithModel.getOffset(itemStack);
+        tile.setOffset(offset[0], offset[1], offset[2], true);
+        tile.setRotation(ItemWithModel.getRotation(itemStack), true);
+    }
+
+    public static void copyOffsetToItemStack(TileEntityPlaceable tileEntity, ItemStack itemStack) {
+        ItemWithModel.setOffset(itemStack, tileEntity.getOffsetX(), tileEntity.getOffsetY(), tileEntity.getOffsetZ());
+        ItemWithModel.setRotation(itemStack, tileEntity.getRotation());
     }
 }

--- a/src/main/java/jp/ngt/rtm/item/ItemWithModel.java
+++ b/src/main/java/jp/ngt/rtm/item/ItemWithModel.java
@@ -47,6 +47,12 @@ public abstract class ItemWithModel extends Item implements IModelSelectorWithTy
     @SideOnly(Side.CLIENT)
     public void addInformation(ItemStack itemStack, EntityPlayer player, List list, boolean par4) {
         list.add(EnumChatFormatting.GRAY + getModelName(itemStack));
+        if (this.getModelState(itemStack).getDataMap().getEntries().size() > 0) {
+            list.add(EnumChatFormatting.DARK_PURPLE + "(+DataMap)");
+        }
+        if (ItemWithModel.hasOffset(itemStack)) {
+            list.add(EnumChatFormatting.DARK_PURPLE + "(+Offset)");
+        }
     }
 
     protected abstract String getModelType(ItemStack itemStack);


### PR DESCRIPTION
架線柱/碍子/入出力コネクタのオフセット情報を左Ctrlキー押下状態でスポイトした場合にアイテムへ保存する機能の追加(closes #218)
ResourceStateが存在するアイテム内にDataMapやOffsetが保存されているかをToolTipに表示する機能の追加(As in **(+NBT)**)