### PR TITLE
Train panel

### DIFF
--- a/src/main/java/jp/ngt/rtm/gui/GuiTrainControlPanel.java
+++ b/src/main/java/jp/ngt/rtm/gui/GuiTrainControlPanel.java
@@ -323,6 +323,59 @@ public class GuiTrainControlPanel extends InventoryEffectRenderer {
             }
             //((ContainerTrainControlPanel)this.inventorySlots).scrollTo(this.currentScroll);
         }
+        if (i != 0) {
+            int x = Mouse.getEventX() * this.width / this.mc.displayWidth;
+            int y = this.height - Mouse.getEventY() * this.height / this.mc.displayHeight - 1;
+            int i0 = (i > 0) ? -1 : 1;
+            ((List<GuiButton>) this.buttonList).stream()
+                    .filter(button -> button.mousePressed(this.mc, x, y))
+                    .findFirst()
+                    .ifPresent(button -> {
+                        int id, data, prevData;
+                        if (button.id == 129) {
+                            String[][] announce = (this.modelset.getConfig()).sound_Announcement;
+                            id = 9;
+                            prevData = this.train.getTrainStateData(id);
+                            data = prevData + i0;
+                            if (announce != null && data >= announce.length) {
+                                data = 0;
+                            } else if (announce != null && data < 0) {
+                                data = announce.length - 1;
+                            }
+                        } else if (button.id >= 124 && button.id <= 128) {
+                            id = button.id - 120;
+                            if (button.id == 124) {
+                                id = TrainStateType.State_InteriorLight.id;
+                            }
+                            prevData = this.train.getTrainStateData(id);
+                            data = prevData + i0;
+                        } else if (button.id >= CUSTOM_BUTTOM_ID) {
+                            int index = button.id - CUSTOM_BUTTOM_ID;
+                            String[] sa = this.getCustomButtons()[index];
+                            int val = this.dataValues[index] + i0;
+                            if (val >= sa.length) {
+                                val = 0;
+                            } else if (val < 0) {
+                                val = sa.length - 1;
+                            }
+                            button.func_146113_a(this.mc.getSoundHandler());
+                            button.displayString = sa[val];
+                            this.dataValues[index] = val;
+                            this.onCustomButtonClick(index, val);
+                            return;
+                        } else {
+                            return;
+                        }
+
+                        if (prevData != data) {
+                            TrainStateType stateType = TrainState.getStateType(id);
+                            data = data < stateType.min ? stateType.max : (data > stateType.max ? stateType.min : data);
+                            this.sendTrainState(id, (byte) data);
+                            button.func_146113_a(this.mc.getSoundHandler());
+                            button.displayString = this.getFormattedText(id, (byte) data);
+                        }
+                    });
+        }
     }
 
     @Override

--- a/src/main/java/jp/ngt/rtm/gui/GuiTrainControlPanel.java
+++ b/src/main/java/jp/ngt/rtm/gui/GuiTrainControlPanel.java
@@ -185,7 +185,8 @@ public class GuiTrainControlPanel extends InventoryEffectRenderer {
                 int value = this.train.getResourceState().getDataMap().getInt("Button" + i);
                 int x = this.guiLeft + 4 + (i % 3) * (54 + 3);
                 int y = this.guiTop + 4 + (i / 3) * (20 + 4);
-                this.buttonList.add(new GuiButton(CUSTOM_BUTTOM_ID + i, x, y, 54, 20, sa[i][value]));
+                String displayString = sa[i].length > value ? sa[i][value] : "Out of range";
+                this.buttonList.add(new GuiButton(CUSTOM_BUTTOM_ID + i, x, y, 54, 20, displayString));
                 this.dataValues[i] = value;
             });
         } else if (tab == TabTrainControlPanel.TAB_Formation) {

--- a/src/main/java/jp/ngt/rtm/gui/GuiTrainControlPanel.java
+++ b/src/main/java/jp/ngt/rtm/gui/GuiTrainControlPanel.java
@@ -26,6 +26,7 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.Slot;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
+import org.lwjgl.input.Keyboard;
 import org.lwjgl.input.Mouse;
 import org.lwjgl.opengl.GL11;
 import org.lwjgl.opengl.GL12;
@@ -442,6 +443,30 @@ public class GuiTrainControlPanel extends InventoryEffectRenderer {
 
         GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
         GL11.glDisable(GL11.GL_LIGHTING);
+    }
+
+    @Override
+    protected void keyTyped(char par1, int par2) {
+        super.keyTyped(par1, par2);
+        if (par2 == Keyboard.KEY_F) {
+
+            int x = Mouse.getEventX() * this.width / this.mc.displayWidth;
+            int y = this.height - Mouse.getEventY() * this.height / this.mc.displayHeight - 1;
+            ((List<GuiButton>) this.buttonList).stream()
+                    .filter(button -> button.id >= CUSTOM_BUTTOM_ID)
+                    .filter(button -> button.mousePressed(this.mc, x, y))
+                    .findFirst()
+                    .ifPresent(button -> {
+                        int index = button.id - CUSTOM_BUTTOM_ID;
+                        int val = this.dataValues[index];
+                        Arrays.stream(this.train.getFormation().entries)
+                                .filter(Objects::nonNull)
+                                .map(entry -> entry.train)
+                                .filter(Objects::nonNull)
+                                .forEach(train -> train.getResourceState().getDataMap().setInt("Button" + index, val, 3));
+                        button.func_146113_a(this.mc.getSoundHandler());
+                    });
+        }
     }
 
     @Override


### PR DESCRIPTION
カスタムボタンの値が範囲外の時に列車Guiを開くとクラッシュする問題を修正(closes #185)
列車Gui内のボタンの上にカーソルを置き、ホイールを回すことで値を増減させる機能を追加
カスタムボタンの上にカーソルを置き、Fキーを押すことでカスタムボタンの値を全車に反映する機能を追加(closes #215)