### PR TITLE
fix(entity/trains): train overlapped when moved after connecting other train and changing direction

### DIFF
--- a/src/main/java/jp/ngt/rtm/entity/train/util/Formation.java
+++ b/src/main/java/jp/ngt/rtm/entity/train/util/Formation.java
@@ -291,6 +291,7 @@ public class Formation {
         {
             if (data == TrainState.Direction_Front.data || data == TrainState.Direction_Back.data) {
                 this.controlCar = par2;
+                par2.setTrainDirection(par2.getTrainDirection());
             }
 
             Arrays.stream(this.entries).filter(Objects::nonNull).map(entry -> entry.train).filter(Objects::nonNull).forEach(train -> {


### PR DESCRIPTION
列車を連結後に運転台から降車せず逆転ハンドルを前または後にして走行すると、列車が重なることがある問題を修正