### PR TITLE
Improve rail

### DIFF
--- a/src/main/java/jp/ngt/rtm/RTMConfig.java
+++ b/src/main/java/jp/ngt/rtm/RTMConfig.java
@@ -34,6 +34,7 @@ public class RTMConfig {
     public static boolean use1122Marker;
     public static int loadSpeed;
     public static boolean expandPlayableSoundCount;
+    public static boolean markerDistanceMoreRealPosition = true;
 
     public static void init(Configuration config) {
         cfg = config;
@@ -85,6 +86,9 @@ public class RTMConfig {
 
         RTMConfig.loadSpeed = cfg.getInt(
                 "ModelPack load speed", CATEGORY_LOAD, 2, 1, 3, "1:Slow 2:Default 3:Fast");
+
+        RTMConfig.markerDistanceMoreRealPosition = cfg.getBoolean(
+                "markerDistancesMoreRealPosition", CATEGORY_MARKER, true, "shows distance signs of marker at more real position");
 
         cfg.save();
     }

--- a/src/main/java/jp/ngt/rtm/rail/BlockLargeRailBase.java
+++ b/src/main/java/jp/ngt/rtm/rail/BlockLargeRailBase.java
@@ -6,7 +6,6 @@ import jp.ngt.ngtlib.block.BlockUtil;
 import jp.ngt.ngtlib.util.PermissionManager;
 import jp.ngt.rtm.RTMBlock;
 import jp.ngt.rtm.RTMCore;
-import jp.ngt.rtm.RTMItem;
 import jp.ngt.rtm.RTMMaterial;
 import jp.ngt.rtm.entity.train.EntityBogie;
 import jp.ngt.rtm.entity.train.EntityTrainBase;
@@ -140,12 +139,9 @@ public class BlockLargeRailBase extends BlockContainer {
     public ItemStack getPickBlock(MovingObjectPosition target, World world, int x, int y, int z, EntityPlayer player) {
         TileEntity tileEntity = world.getTileEntity(x, y, z);
         if (tileEntity instanceof TileEntityLargeRailBase) {
-            ItemStack itemStack = new ItemStack(RTMItem.itemLargeRail);
             TileEntityLargeRailCore coreTile = ((TileEntityLargeRailBase) tileEntity).getRailCore();
             if (coreTile != null) {
-                RailProperty property = coreTile.getProperty();
-                ItemRail.writePropToItem(property, itemStack);
-                return itemStack;
+                return ItemRail.copyItemFromRail(coreTile);
             }
         }
         return null;

--- a/src/main/java/jp/ngt/rtm/rail/RenderMarkerBlockBase.java
+++ b/src/main/java/jp/ngt/rtm/rail/RenderMarkerBlockBase.java
@@ -109,6 +109,31 @@ public abstract class RenderMarkerBlockBase {
         }
 
         GL11.glPopMatrix();
+
+        GL11.glPushMatrix();
+        GL11.glTranslatef(x, y, z);
+
+        GL11.glEnable(GL11.GL_TEXTURE_2D);
+        FontRenderer fontRenderer = RenderManager.instance.getFontRenderer();
+        for (RailMap rm : tileEntity.getRailMaps()) {
+            GL11.glPushMatrix();
+            int split = (int) (rm.getLength() * 4.0D);
+            double[] pos = rm.getRailPos(split, split / 2);
+            float x0 = (float) (pos[1] - tileEntity.getMarkerRP().posX);
+            float y0 = (float) ((rm.getStartRP().posY + rm.getEndRP().posY) / 2 - tileEntity.getMarkerRP().posY);
+            float z0 = (float) (pos[0] - tileEntity.getMarkerRP().posZ);
+            GL11.glTranslatef(x0, y0, z0);
+            GL11.glScalef(-0.05F, -0.05F, -0.05F);
+            GL11.glRotatef(-RenderManager.instance.playerViewY, 0.0F, 1.0F, 0.0F);
+            String s = String.valueOf((float) Math.round(rm.getLength() * 10000) / 10000);
+            int stringWidth = fontRenderer.getStringWidth(s);
+            fontRenderer.drawString(s, -stringWidth / 2, -10, 0x00EE00);
+            GL11.glPopMatrix();
+        }
+
+        GL11.glDisable(GL11.GL_TEXTURE_2D);
+
+        GL11.glPopMatrix();
     }
 
     protected void renderGrid(TileEntityMarker marker) {

--- a/src/main/java/jp/ngt/rtm/rail/TileEntityLargeRailCore.java
+++ b/src/main/java/jp/ngt/rtm/rail/TileEntityLargeRailCore.java
@@ -360,4 +360,9 @@ public abstract class TileEntityLargeRailCore extends TileEntityLargeRailBase {
         Arrays.stream(this.railPositions).forEach(rp -> rp.movePos(difX, difY, difZ));
         super.setPos(x, y, z, prevX, prevY, prevZ);
     }
+
+    /**
+     * レール形状の説明を取得(アイテム表示用)
+     */
+    public abstract String getRailShapeName();
 }

--- a/src/main/java/jp/ngt/rtm/rail/TileEntityLargeRailNormalCore.java
+++ b/src/main/java/jp/ngt/rtm/rail/TileEntityLargeRailNormalCore.java
@@ -1,5 +1,14 @@
 package jp.ngt.rtm.rail;
 
+import jp.ngt.rtm.rail.util.RailMap;
+
 public class TileEntityLargeRailNormalCore extends TileEntityLargeRailCore {
-    ;
+    @Override
+    public String getRailShapeName() {
+        RailMap map = this.getRailMap(null);
+        return "Type:Normal, " +
+                "X:" + (map.getEndRP().blockX - map.getStartRP().blockX) + ", " +
+                "Y:" + (map.getEndRP().blockY - map.getStartRP().blockY) + ", " +
+                "Z:" + (map.getEndRP().blockZ - map.getStartRP().blockZ);
+    }
 }

--- a/src/main/java/jp/ngt/rtm/rail/TileEntityLargeRailSlopeCore.java
+++ b/src/main/java/jp/ngt/rtm/rail/TileEntityLargeRailSlopeCore.java
@@ -4,6 +4,7 @@ import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import jp.ngt.rtm.RTMCore;
 import jp.ngt.rtm.network.PacketLargeRailCore;
+import jp.ngt.rtm.rail.util.RailMap;
 import jp.ngt.rtm.rail.util.RailMapSlope;
 import net.minecraft.nbt.NBTTagCompound;
 
@@ -70,5 +71,15 @@ public class TileEntityLargeRailSlopeCore extends TileEntityLargeRailCore {
         int minZ = Math.min(startZ, endZ);
         int maxZ = Math.max(startZ, endZ);
         return new int[]{minX, minY, minZ, maxX, maxY, maxZ};
+    }
+
+
+    @Override
+    public String getRailShapeName() {
+        RailMap map = this.getRailMap(null);
+        return "Type:Normal, " +
+                "X:" + (map.getEndRP().blockX - map.getStartRP().blockX) + ", " +
+                "Y:" + (map.getEndRP().blockY - map.getStartRP().blockY) + ", " +
+                "Z:" + (map.getEndRP().blockZ - map.getStartRP().blockZ);
     }
 }

--- a/src/main/java/jp/ngt/rtm/rail/TileEntityLargeRailSwitchCore.java
+++ b/src/main/java/jp/ngt/rtm/rail/TileEntityLargeRailSwitchCore.java
@@ -165,4 +165,14 @@ public class TileEntityLargeRailSwitchCore extends TileEntityLargeRailCore {
         }
         return new int[]{minX, minY, minZ, maxX, maxY, maxZ};
     }
+
+    @Override
+    public String getRailShapeName() {
+        SwitchType st = this.getSwitch();
+        int[] box = this.getRailSize();
+        return "Type:Switch " + st.getName() + ", " +
+                "X:" + (box[3] - box[0]) + ", " +
+                "Y:" + (box[4] - box[1]) + ", " +
+                "Z:" + (box[5] - box[2]);
+    }
 }

--- a/src/main/java/jp/ngt/rtm/rail/TileEntityTurnTableCore.java
+++ b/src/main/java/jp/ngt/rtm/rail/TileEntityTurnTableCore.java
@@ -8,6 +8,7 @@ import jp.ngt.rtm.RTMCore;
 import jp.ngt.rtm.entity.train.EntityTrainBase;
 import jp.ngt.rtm.entity.train.util.BogieController.UpdateFlag;
 import jp.ngt.rtm.network.PacketNotice;
+import jp.ngt.rtm.rail.util.RailMap;
 import jp.ngt.rtm.rail.util.RailMapTurntable;
 import jp.ngt.rtm.rail.util.RailPosition;
 import net.minecraft.nbt.NBTTagCompound;
@@ -132,14 +133,12 @@ public class TileEntityTurnTableCore extends TileEntityLargeRailCore {
         }
     }
 
-//    @Override
-//    public String getRailShapeName() {
-//        RailMap map = this.getRailMap(null);
-//        StringBuilder sb = new StringBuilder();
-//        sb.append("Type:TurnTable, ");
-//        sb.append("X:").append(map.getEndRP().blockX - map.getStartRP().blockX).append(", ");
-//        sb.append("Y:").append(map.getEndRP().blockY - map.getStartRP().blockY).append(", ");
-//        sb.append("Z:").append(map.getEndRP().blockZ - map.getStartRP().blockZ);
-//        return sb.toString();
-//    }
+    @Override
+    public String getRailShapeName() {
+        RailMap map = this.getRailMap(null);
+        return "Type:TurnTable, " +
+                "X:" + (map.getEndRP().blockX - map.getStartRP().blockX) + ", " +
+                "Y:" + (map.getEndRP().blockY - map.getStartRP().blockY) + ", " +
+                "Z:" + (map.getEndRP().blockZ - map.getStartRP().blockZ);
+    }
 }

--- a/src/main/java/jp/ngt/rtm/rail/util/RailMapSlope.java
+++ b/src/main/java/jp/ngt/rtm/rail/util/RailMapSlope.java
@@ -112,35 +112,33 @@ public class RailMapSlope extends RailMapBasic {
         return this.dirDeg;
     }
 
-//    @Override
-//    public float getRailPitch() {
-//        switch (this.slopeType) {
-//            case 0:
-//                return 3.576334F;
-//            case 1:
-//                return 7.125016F;
-//            case 2:
-//                return 14.03624F;
-//            case 3:
-//                return 26.56505F;
-//            default:
-//                return 3.576334F;
-//        }
-//    }
+    @Override
+    public float getRailPitch(int par1, int par2) {
+        switch (this.slopeType) {
+            case 1:
+                return 7.125016F;
+            case 2:
+                return 14.03624F;
+            case 3:
+                return 26.56505F;
+            case 0:
+            default:
+                return 3.576334F;
+        }
+    }
 
-//    @Override
-//    public double getLength() {
-//        switch (this.slopeType) {
-//            case 0:
-//                return 16.0D;
-//            case 1:
-//                return 8.0D;
-//            case 2:
-//                return 4.0D;
-//            case 3:
-//                return 2.0D;
-//            default:
-//                return 16.0D;
-//        }
-//    }
+    @Override
+    public double getLength() {
+        switch (this.slopeType) {
+            case 1:
+                return 8.0D;
+            case 2:
+                return 4.0D;
+            case 3:
+                return 2.0D;
+            case 0:
+            default:
+                return 16.0D;
+        }
+    }
 }

--- a/src/main/java/jp/ngt/rtm/rail/util/RailPosition.java
+++ b/src/main/java/jp/ngt/rtm/rail/util/RailPosition.java
@@ -30,7 +30,7 @@ public class RailPosition {
     /**
      * ブロックとしての向き 0~7
      */
-    public final byte direction;
+    public byte direction;
     /**
      * 0~15
      */

--- a/src/main/java/jp/ngt/rtm/rail/util/SwitchType.java
+++ b/src/main/java/jp/ngt/rtm/rail/util/SwitchType.java
@@ -24,6 +24,8 @@ public abstract class SwitchType {
      */
     public abstract boolean init(List<RailPosition> switchList, List<RailPosition> normalList);
 
+    public abstract String getName();
+
     /**
      * ブロック更新時に呼ばれる
      */
@@ -108,6 +110,11 @@ public abstract class SwitchType {
         @Override
         public RailMap getRailMap(Entity entity) {
             return this.points[0].getActiveRailMap(entity.worldObj);
+        }
+
+        @Override
+        public String getName() {
+            return "Simple";
         }
     }
 
@@ -197,6 +204,11 @@ public abstract class SwitchType {
 				if(a2 > 90.0F){a2 = 180.0F - 90.0F;}
 				return a1 < a2 ? map1 : map2;*/
             }
+        }
+
+        @Override
+        public String getName() {
+            return "Crossover";
         }
     }
 
@@ -354,6 +366,11 @@ public abstract class SwitchType {
             }
             return map;
         }
+
+        @Override
+        public String getName() {
+            return "Scissors Crossing";
+        }
     }
 
     /****************************************************************************************************/
@@ -422,6 +439,11 @@ public abstract class SwitchType {
             double d1 = entity.getDistanceSq(pos1[1], 0.0D, pos1[0]);
             double d2 = entity.getDistanceSq(pos2[1], 0.0D, pos2[0]);
             return d1 < d2 ? map1 : map2;
+        }
+
+        @Override
+        public String getName() {
+            return "Diamond Crossing";
         }
     }
 }


### PR DESCRIPTION
マーカーの距離目標を正確な座標に描画する機能を移植(fixrtm/fixRTM@145d01878d4c83439b748fa8336ab6b11fdf7b61)
マーカーでレール線表示時にその中央に長さを表示する機能を追加
レールコピー時にレールブロックもコピーし、ブロックに対してクリックすることでレールを敷設する機能を移植
古い坂レールを読み込み時にクラッシュする問題を修正(#287)