### PR TITLE
Improve container

### DIFF
--- a/src/main/java/jp/ngt/rtm/entity/train/parts/EntityArtillery.java
+++ b/src/main/java/jp/ngt/rtm/entity/train/parts/EntityArtillery.java
@@ -304,4 +304,9 @@ public class EntityArtillery extends EntityCargoWithModel<ModelSetFirearm> {
     public String getDefaultName() {
         return "40cmArtillery";
     }
+
+    @Override
+    protected ItemStack getItem() {
+        return new ItemStack(RTMItem.itemCargo, 1, 1);
+    }
 }

--- a/src/main/java/jp/ngt/rtm/entity/train/parts/EntityCargo.java
+++ b/src/main/java/jp/ngt/rtm/entity/train/parts/EntityCargo.java
@@ -100,20 +100,20 @@ public abstract class EntityCargo extends EntityVehiclePart {
 
     @Override
     public boolean attackEntityFrom(DamageSource par1, float par2) {
-        if (this.isEntityInvulnerable() || this.isDead) {
-            return false;
-        } else {
+        if (!this.isEntityInvulnerable() && !this.isDead) {
             if (!par1.isExplosion() && par1.getEntity() instanceof EntityPlayer) {
                 if (!this.worldObj.isRemote) {
                     if (this.isIndependent || this.getVehicle() == null) {
                         this.setDead();
-                        this.dropCargoItem();
+                        if (!((EntityPlayer) par1.getEntity()).capabilities.isCreativeMode) {
+                            this.dropCargoItem();
+                        }
                     }
                 }
                 return true;
             }
-            return false;
         }
+        return false;
     }
 
     /**

--- a/src/main/java/jp/ngt/rtm/entity/train/parts/EntityCargoWithModel.java
+++ b/src/main/java/jp/ngt/rtm/entity/train/parts/EntityCargoWithModel.java
@@ -1,7 +1,9 @@
 package jp.ngt.rtm.entity.train.parts;
 
 import jp.ngt.rtm.RTMCore;
+import jp.ngt.rtm.RTMItem;
 import jp.ngt.rtm.entity.vehicle.EntityVehicleBase;
+import jp.ngt.rtm.item.ItemWithModel;
 import jp.ngt.rtm.modelpack.IModelSelector;
 import jp.ngt.rtm.modelpack.ModelPackManager;
 import jp.ngt.rtm.modelpack.modelset.ModelSetBase;
@@ -9,6 +11,7 @@ import jp.ngt.rtm.modelpack.state.ResourceState;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.util.MovingObjectPosition;
 import net.minecraft.world.World;
 
 public abstract class EntityCargoWithModel<T extends ModelSetBase> extends EntityCargo implements IModelSelector {
@@ -104,4 +107,20 @@ public abstract class EntityCargoWithModel<T extends ModelSetBase> extends Entit
     }
 
     public abstract String getDefaultName();
+
+    @Override
+    public ItemStack getPickedResult(MovingObjectPosition target) {
+        if (target.entityHit instanceof EntityCargoWithModel) {
+            EntityCargoWithModel<?> cargo = (EntityCargoWithModel<?>) target.entityHit;
+            ItemStack itemStack = this.getItem();
+            ((ItemWithModel) RTMItem.itemCargo).setModelName(itemStack, cargo.getModelName());
+
+            ((ItemWithModel) RTMItem.itemCargo).setModelState(itemStack, cargo.getResourceState());
+            return itemStack;
+        } else {
+            return null;
+        }
+    }
+
+    protected abstract ItemStack getItem();
 }

--- a/src/main/java/jp/ngt/rtm/entity/train/parts/EntityContainer.java
+++ b/src/main/java/jp/ngt/rtm/entity/train/parts/EntityContainer.java
@@ -4,6 +4,7 @@ import jp.ngt.ngtlib.item.ItemUtil;
 import jp.ngt.ngtlib.math.PooledVec3;
 import jp.ngt.ngtlib.math.Vec3;
 import jp.ngt.rtm.RTMCore;
+import jp.ngt.rtm.RTMItem;
 import jp.ngt.rtm.entity.train.EntityBogie;
 import jp.ngt.rtm.entity.vehicle.EntityVehicleBase;
 import jp.ngt.rtm.item.ItemCargo;
@@ -282,5 +283,10 @@ public class EntityContainer extends EntityCargoWithModel<ModelSetContainer> imp
     @Override
     public String getDefaultName() {
         return "19g_JRF_0";
+    }
+
+    @Override
+    protected ItemStack getItem() {
+        return new ItemStack(RTMItem.itemCargo, 1, 0);
     }
 }

--- a/src/main/java/jp/ngt/rtm/entity/train/parts/EntityContainer.java
+++ b/src/main/java/jp/ngt/rtm/entity/train/parts/EntityContainer.java
@@ -74,7 +74,9 @@ public class EntityContainer extends EntityCargoWithModel<ModelSetContainer> imp
             });
 
             NBTTagCompound itemNBT = this.itemCargo.hasTagCompound() ? this.itemCargo.getTagCompound() : new NBTTagCompound();
-            itemNBT.setTag("Items", tagList);
+            if (tagList.tagCount() != 0) {
+                itemNBT.setTag("Items", tagList);
+            }
             itemNBT.setString("ModelName", this.getModelName());
             this.itemCargo.setTagCompound(itemNBT);
         }

--- a/src/main/java/jp/ngt/rtm/item/ItemCargo.java
+++ b/src/main/java/jp/ngt/rtm/item/ItemCargo.java
@@ -3,10 +3,7 @@ package jp.ngt.rtm.item;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import jp.ngt.ngtlib.math.NGTMath;
-import jp.ngt.rtm.entity.train.parts.EntityArtillery;
-import jp.ngt.rtm.entity.train.parts.EntityCargo;
-import jp.ngt.rtm.entity.train.parts.EntityContainer;
-import jp.ngt.rtm.entity.train.parts.EntityTie;
+import jp.ngt.rtm.entity.train.parts.*;
 import jp.ngt.rtm.modelpack.cfg.ContainerConfig;
 import jp.ngt.rtm.modelpack.cfg.FirearmConfig;
 import net.minecraft.client.renderer.texture.IIconRegister;
@@ -62,7 +59,7 @@ public class ItemCargo extends ItemWithModel {
                 ++par4;
             }
 
-            ItemStack itemstack = itemStack.copy();
+            ItemStack itemstack = itemStack.splitStack(1);
             int damage = itemstack.getItemDamage();
             EntityCargo cargo = this.createCargoEntity(world, itemstack, par4, par5, par6, damage);
             float rotationInterval = 15.0F;
@@ -71,14 +68,12 @@ public class ItemCargo extends ItemWithModel {
             cargo.setPositionAndRotation((double) par4 + 0.5D, par5, (double) par6 + 0.5D, yawF, 0.0F);
             cargo.readCargoFromItem();
 
-            if (damage == 1 && ((EntityArtillery) cargo).getModelName().isEmpty()) {
-                ((EntityArtillery) cargo).setModelName(getModelName(itemstack));
-            } else if (damage == 0 && ((EntityContainer) cargo).getModelName().isEmpty()) {
-                ((EntityContainer) cargo).setModelName(getModelName(itemstack));
+            if (cargo instanceof EntityCargoWithModel) {
+                EntityCargoWithModel cwm = (EntityCargoWithModel) cargo;
+                cwm.getResourceState().readFromNBT(this.getModelState(itemstack).writeToNBT());
             }
 
             world.spawnEntityInWorld(cargo);
-            --itemStack.stackSize;
         }
         return true;
     }

--- a/src/main/java/jp/ngt/rtm/item/ItemWithModel.java
+++ b/src/main/java/jp/ngt/rtm/item/ItemWithModel.java
@@ -148,7 +148,7 @@ public abstract class ItemWithModel extends Item implements IModelSelectorWithTy
         itemStack.getTagCompound().setTag("State", state.writeToNBT());
 
         if (this.selectedPlayer != null) {
-            NGTUtil.sendPacketToServer(this.selectedPlayer, this.selectedItem);
+            NGTUtil.sendPacketToServer(this.selectedPlayer, itemStack);
         }
     }
 


### PR DESCRIPTION
コンテナの上にコンテナを設置するとデフォルトモデルになる問題を修正(closes #294)
コンテナを破壊したときにドロップするコンテナアイテムがスタックされない問題を修正
コンテナとコンテナの間にコンテナが置けない問題を修正
クリエイティブモード時にコンテナを破壊したときにコンテナ自身がアイテムとしてドロップする問題を修正
コンテナでもマウスピッキングした際にアイテムを取得する機能を追加