### PR TITLE
Extend audible range

### DIFF
--- a/src/main/java/jp/ngt/rtm/ClientProxy.java
+++ b/src/main/java/jp/ngt/rtm/ClientProxy.java
@@ -171,7 +171,7 @@ public class ClientProxy extends CommonProxy {
             return;
         }
 
-        List<File> fileList = NGTFileLoader.findFile((file) -> file.getName().equals("pack.json"));
+        List<File> fileList = NGTFileLoader.findFile(file -> file.getName().equals("pack.json"));
         try {
             fileList.stream()
                     .map(NGTJson::readFromJson)
@@ -315,6 +315,7 @@ public class ClientProxy extends CommonProxy {
                 MovingSoundEntity ms = new MovingSoundEntity(entity, sound, false);
                 ms.setVolume(vol);
                 ms.setPitch(pitch);
+                ms.update();
                 NGTUtilClient.playSound(ms);
             }
         }
@@ -329,6 +330,7 @@ public class ClientProxy extends CommonProxy {
                 MovingSoundTileEntity ms = new MovingSoundTileEntity(entity, sound, false);
                 ms.setVolume(vol);
                 ms.setPitch(pitch);
+                ms.update();
                 NGTUtilClient.playSound(ms);
             }
         }

--- a/src/main/java/jp/ngt/rtm/entity/train/EntityBogie.java
+++ b/src/main/java/jp/ngt/rtm/entity/train/EntityBogie.java
@@ -6,7 +6,6 @@ import jp.ngt.ngtlib.io.NGTLog;
 import jp.ngt.ngtlib.math.NGTMath;
 import jp.ngt.ngtlib.math.Vec3;
 import jp.ngt.ngtlib.protection.Lockable;
-import jp.ngt.ngtlib.util.PermissionManager;
 import jp.ngt.ngtlib.world.NGTWorld;
 import jp.ngt.rtm.RTMAchievement;
 import jp.ngt.rtm.RTMCore;
@@ -329,7 +328,7 @@ public class EntityBogie extends Entity implements Lockable {
         if (!cfg.muteJointSound) {
             float pitch = (Math.abs(train.getSpeed()) / cfg.maxSpeed[cfg.maxSpeed.length - 1]) * 0.5F + 1.0F;
             ResourceLocation sound = this.reverbSound ? JOINT_SOUND_REVERB : JOINT_SOUND;
-            RTMCore.proxy.playSound(this, sound, 1.0F, pitch);
+            RTMCore.proxy.playSound(this, sound, 4.0F, pitch);
 
             int size = cfg.jointDelay[this.getBogieId()].length;
             if (this.jointIndex < size - 1) {

--- a/src/main/java/jp/ngt/rtm/entity/train/EntityTrainBase.java
+++ b/src/main/java/jp/ngt/rtm/entity/train/EntityTrainBase.java
@@ -468,7 +468,7 @@ public abstract class EntityTrainBase extends EntityVehicleBase<TrainConfig> imp
 
         if (sound != null) {
             String[] sa = sound.split(":");
-            RTMCore.proxy.playSound(this, new ResourceLocation(sa[0], sa[1]), 1.0F, 1.0F);
+            RTMCore.proxy.playSound(this, new ResourceLocation(sa[0], sa[1]), 2.0F, 1.0F);
             //this.worldObj.playSoundAtEntity(this, sound, 1.0F, 1.0F);
         }
     }

--- a/src/main/java/jp/ngt/rtm/event/RTMKeyHandlerServer.java
+++ b/src/main/java/jp/ngt/rtm/event/RTMKeyHandlerServer.java
@@ -25,7 +25,7 @@ public final class RTMKeyHandlerServer {
         if (keyCode == RTMCore.KEY_SNEAK) {
             this.setVehicleState(player, -1);
         } else if (keyCode == RTMCore.KEY_Horn) {
-            this.playSound(player, sound, 10000.0F, false);
+            this.playSound(player, sound, 6F, false);
         } else if (keyCode == RTMCore.KEY_Chime) {
             this.playSound(player, sound, 1.0F, true);
         } else if (keyCode == RTMCore.KEY_ControlPanel) {

--- a/src/main/java/jp/ngt/rtm/sound/SoundPlayer.java
+++ b/src/main/java/jp/ngt/rtm/sound/SoundPlayer.java
@@ -32,7 +32,7 @@ public class SoundPlayer {
                 this.stopSound();
             }
             this.sound = new MovingSoundTileEntity(tile, src, repeat);
-            this.sound.setVolume(10.0F);
+            this.sound.setVolume(4.0F);
             this.sound.update();
             NGTUtilClient.playSound(this.sound);
         }

--- a/src/main/java/jp/ngt/rtm/sound/SoundPlayer.java
+++ b/src/main/java/jp/ngt/rtm/sound/SoundPlayer.java
@@ -33,6 +33,7 @@ public class SoundPlayer {
             }
             this.sound = new MovingSoundTileEntity(tile, src, repeat);
             this.sound.setVolume(10.0F);
+            this.sound.update();
             NGTUtilClient.playSound(this.sound);
         }
 

--- a/src/main/java/jp/ngt/rtm/sound/SoundUpdaterVehicle.java
+++ b/src/main/java/jp/ngt/rtm/sound/SoundUpdaterVehicle.java
@@ -43,7 +43,6 @@ public class SoundUpdaterVehicle implements IUpdateVehicle {
             //RTMUtil.doScriptFunction(modelset.se, "onUpdate", this);
             ScriptUtil.doScriptIgnoreError(modelset.se, "onUpdate", this);
         } else {
-            boolean flag = false;
             if (this.theVehicle.isDead) {
                 if (this.prevSound != null) {
                     ((MovingSoundVehicle) this.prevSound).stop();
@@ -65,7 +64,6 @@ public class SoundUpdaterVehicle implements IUpdateVehicle {
                 this.theSoundHandler.playSound(sound);
                 this.prevSound = sound;
                 this.silent = false;
-                flag = true;
             }
         }
     }
@@ -121,6 +119,7 @@ public class SoundUpdaterVehicle implements IUpdateVehicle {
         }
         sound.setVolume(volume);
         sound.setPitch(pitch);
+        sound.update();
 
         if (flag) {
             this.theSoundHandler.playSound(sound);


### PR DESCRIPTION
- Volumeを1以上にしたときに可聴範囲が拡張されない問題を修正
- 踏切音可聴範囲を64ブロックに設定
- 警笛可聴距離を96ブロックに設定
- ブレーキ緩解音可聴範囲を32ブロックに設定
- 台車ジョイント音可聴範囲を64ブロックに設定