### PR TITLE
fix(sound): if initial volume is 0, can't listen it even if increase volume after that

### DIFF
--- a/src/main/java/jp/ngt/rtm/sound/SoundUpdaterVehicle.java
+++ b/src/main/java/jp/ngt/rtm/sound/SoundUpdaterVehicle.java
@@ -114,6 +114,9 @@ public class SoundUpdaterVehicle implements IUpdateVehicle {
         MovingSoundVehicle sound = this.getPlayingSound(domain, path);
         boolean flag = (sound == null);
         if (flag) {
+            if (volume == 0) {
+                return;
+            }
             ResourceLocation resource = new ResourceLocation(domain, path);
             sound = new MovingSoundVehicle(this.theVehicle, resource, repeat, false);
         }


### PR DESCRIPTION
 closes #335 
最初の音量が0で再生を開始した場合、その後音量を上げても聞こえない問題を修正