### PR TITLE
chore(ci): disable test due to AWS S3 mirror of Minecraft down

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -57,6 +57,11 @@ jobs:
         runs-on: ubuntu-latest
 
         needs: [ build ]
+        
+        # AWS S3 mirror of Minecraft, which is used by forge installer, is down
+        # see https://github.com/Kai-Z-JP/KaizPatchX/issues/327
+        # see https://github.com/itzg/docker-minecraft-server/issues/1814
+        if: false
 
         # Steps represent a sequence of tasks that will be executed as part of the job
         steps:


### PR DESCRIPTION
#327 の一時的な対処