### PR TITLE
fix audible range

### DIFF
--- a/src/main/java/jp/ngt/rtm/ClientProxy.java
+++ b/src/main/java/jp/ngt/rtm/ClientProxy.java
@@ -307,10 +307,10 @@ public class ClientProxy extends CommonProxy {
     }
 
     @Override
-    public void playSound(Entity entity, ResourceLocation sound, float vol, float pitch) {
+    public void playSound(Entity entity, ResourceLocation sound, float vol, float pitch, float range) {
         if (sound != null) {
             if (NGTUtil.isServer()) {
-                super.playSound(entity, sound, vol, pitch);
+                super.playSound(entity, sound, vol, pitch, range);
             } else {
                 MovingSoundEntity ms = new MovingSoundEntity(entity, sound, false);
                 ms.setVolume(vol);
@@ -322,10 +322,10 @@ public class ClientProxy extends CommonProxy {
     }
 
     @Override
-    public void playSound(TileEntity entity, ResourceLocation sound, float vol, float pitch) {
+    public void playSound(TileEntity entity, ResourceLocation sound, float vol, float pitch, float range) {
         if (sound != null) {
             if (NGTUtil.isServer()) {
-                super.playSound(entity, sound, vol, pitch);
+                super.playSound(entity, sound, vol, pitch, range);
             } else {
                 MovingSoundTileEntity ms = new MovingSoundTileEntity(entity, sound, false);
                 ms.setVolume(vol);

--- a/src/main/java/jp/ngt/rtm/ClientProxy.java
+++ b/src/main/java/jp/ngt/rtm/ClientProxy.java
@@ -312,10 +312,9 @@ public class ClientProxy extends CommonProxy {
             if (NGTUtil.isServer()) {
                 super.playSound(entity, sound, vol, pitch, range);
             } else {
-                MovingSoundEntity ms = new MovingSoundEntity(entity, sound, false);
+                MovingSoundEntity ms = new MovingSoundEntity(entity, sound, false, range);
                 ms.setVolume(vol);
                 ms.setPitch(pitch);
-                ms.update();
                 NGTUtilClient.playSound(ms);
             }
         }
@@ -327,10 +326,9 @@ public class ClientProxy extends CommonProxy {
             if (NGTUtil.isServer()) {
                 super.playSound(entity, sound, vol, pitch, range);
             } else {
-                MovingSoundTileEntity ms = new MovingSoundTileEntity(entity, sound, false);
+                MovingSoundTileEntity ms = new MovingSoundTileEntity(entity, sound, false, range);
                 ms.setVolume(vol);
                 ms.setPitch(pitch);
-                ms.update();
                 NGTUtilClient.playSound(ms);
             }
         }

--- a/src/main/java/jp/ngt/rtm/CommonProxy.java
+++ b/src/main/java/jp/ngt/rtm/CommonProxy.java
@@ -1,5 +1,6 @@
 package jp.ngt.rtm;
 
+import cpw.mods.fml.common.network.NetworkRegistry;
 import cpw.mods.fml.relauncher.Side;
 import jp.ngt.ngtlib.util.NGTUtil;
 import jp.ngt.rtm.entity.train.util.FormationManager;
@@ -79,14 +80,28 @@ public class CommonProxy {
      * @param sound  null可
      */
     public void playSound(Entity entity, ResourceLocation sound, float vol, float pitch) {
+        this.playSound(entity, sound, vol, pitch, 16.0F);
+    }
+
+    public void playSound(Entity entity, ResourceLocation sound, float vol, float pitch, float range) {
         if (sound != null) {
-            RTMCore.NETWORK_WRAPPER.sendToAll(new PacketPlaySound(entity, sound, vol, pitch));
+            RTMCore.NETWORK_WRAPPER.sendToAllAround(
+                    new PacketPlaySound(entity, sound, vol, pitch, range),
+                    new NetworkRegistry.TargetPoint(entity.dimension, entity.posX, entity.posY, entity.posZ, range)
+            );
         }
     }
 
     public void playSound(TileEntity entity, ResourceLocation sound, float vol, float pitch) {
+        this.playSound(entity, sound, vol, pitch, 16.0F);
+    }
+
+    public void playSound(TileEntity entity, ResourceLocation sound, float vol, float pitch, float range) {
         if (sound != null) {
-            RTMCore.NETWORK_WRAPPER.sendToAll(new PacketPlaySound(entity, sound, vol, pitch));
+            RTMCore.NETWORK_WRAPPER.sendToAllAround(
+                    new PacketPlaySound(entity, sound, vol, pitch, range),
+                    new NetworkRegistry.TargetPoint(entity.getWorldObj().provider.dimensionId, entity.xCoord, entity.yCoord, entity.zCoord, range)
+            );
         }
     }
 

--- a/src/main/java/jp/ngt/rtm/RTMConfig.java
+++ b/src/main/java/jp/ngt/rtm/RTMConfig.java
@@ -36,6 +36,12 @@ public class RTMConfig {
     public static boolean expandPlayableSoundCount;
     public static boolean markerDistanceMoreRealPosition = true;
 
+    public static float trainRunningSoundRange;
+    public static float trainJointSoundRange;
+    public static float trainBrakeReleaseSoundRange;
+    public static float trainHornSoundRange;
+    public static float crossingGateSoundRange;
+
     public static void init(Configuration config) {
         cfg = config;
         try {
@@ -57,6 +63,17 @@ public class RTMConfig {
         RTMConfig.expandPlayableSoundCount = cfg.getBoolean(
                 "Expand playable sound count", CATEGORY_SOUND, true,
                 "expands the count of playable sound count at the same time. this may cause compatibility issue with Immersive Vehicles.");
+
+        RTMConfig.trainRunningSoundRange = cfg.getFloat(
+                "audible range train running", CATEGORY_SOUND, 48.0F, 0.0F, 256.0F, "Audible range of train running sound range.(Sounds played from script as well");
+        RTMConfig.trainJointSoundRange = cfg.getFloat(
+                "audible range train joint", CATEGORY_SOUND, 48.0F, 0.0F, 256.0F, "Audible range of train joint sound.(Server Side)");
+        RTMConfig.trainBrakeReleaseSoundRange = cfg.getFloat(
+                "audible range train brake release", CATEGORY_SOUND, 32.0F, 0.0F, 256.0F, "Audible range of train brake release sound.(Server Side)");
+        RTMConfig.trainHornSoundRange = cfg.getFloat(
+                "audible range train horn", CATEGORY_SOUND, 96.0F, 0.0F, 256.0F, "Audible range of train horn sound.(Server Side)");
+        RTMConfig.crossingGateSoundRange = cfg.getFloat(
+                "audible range crossing gate", CATEGORY_SOUND, 32.0F, 0.0F, 256.0F, "Audible range of crossing gate sound.");
 
         RTMConfig.railGeneratingDistance = (short) cfg.getInt(
                 "GeneratingDistance", CATEGORY_RAIL, 64, 0, 256, "Distance for generating a rail. (default:64, recomended max value:256, It depends on server side)");

--- a/src/main/java/jp/ngt/rtm/entity/train/EntityBogie.java
+++ b/src/main/java/jp/ngt/rtm/entity/train/EntityBogie.java
@@ -8,6 +8,7 @@ import jp.ngt.ngtlib.math.Vec3;
 import jp.ngt.ngtlib.protection.Lockable;
 import jp.ngt.ngtlib.world.NGTWorld;
 import jp.ngt.rtm.RTMAchievement;
+import jp.ngt.rtm.RTMConfig;
 import jp.ngt.rtm.RTMCore;
 import jp.ngt.rtm.RTMItem;
 import jp.ngt.rtm.entity.EntityBumpingPost;
@@ -328,7 +329,7 @@ public class EntityBogie extends Entity implements Lockable {
         if (!cfg.muteJointSound) {
             float pitch = (Math.abs(train.getSpeed()) / cfg.maxSpeed[cfg.maxSpeed.length - 1]) * 0.5F + 1.0F;
             ResourceLocation sound = this.reverbSound ? JOINT_SOUND_REVERB : JOINT_SOUND;
-            RTMCore.proxy.playSound(this, sound, 4.0F, pitch);
+            RTMCore.proxy.playSound(this, sound, 1.0F, pitch, RTMConfig.trainJointSoundRange);
 
             int size = cfg.jointDelay[this.getBogieId()].length;
             if (this.jointIndex < size - 1) {

--- a/src/main/java/jp/ngt/rtm/entity/train/EntityTrainBase.java
+++ b/src/main/java/jp/ngt/rtm/entity/train/EntityTrainBase.java
@@ -8,6 +8,7 @@ import jp.ngt.ngtlib.math.PooledVec3;
 import jp.ngt.ngtlib.util.NGTUtil;
 import jp.ngt.ngtlib.util.PermissionManager;
 import jp.ngt.rtm.RTMAchievement;
+import jp.ngt.rtm.RTMConfig;
 import jp.ngt.rtm.RTMCore;
 import jp.ngt.rtm.RTMItem;
 import jp.ngt.rtm.electric.WireManager;
@@ -468,7 +469,7 @@ public abstract class EntityTrainBase extends EntityVehicleBase<TrainConfig> imp
 
         if (sound != null) {
             String[] sa = sound.split(":");
-            RTMCore.proxy.playSound(this, new ResourceLocation(sa[0], sa[1]), 2.0F, 1.0F);
+            RTMCore.proxy.playSound(this, new ResourceLocation(sa[0], sa[1]), 1.0F, 1.0F, RTMConfig.trainBrakeReleaseSoundRange);
             //this.worldObj.playSoundAtEntity(this, sound, 1.0F, 1.0F);
         }
     }

--- a/src/main/java/jp/ngt/rtm/event/RTMKeyHandlerServer.java
+++ b/src/main/java/jp/ngt/rtm/event/RTMKeyHandlerServer.java
@@ -1,5 +1,6 @@
 package jp.ngt.rtm.event;
 
+import jp.ngt.rtm.RTMConfig;
 import jp.ngt.rtm.RTMCore;
 import jp.ngt.rtm.entity.train.EntityTrainBase;
 import jp.ngt.rtm.entity.train.parts.EntityArtillery;
@@ -25,9 +26,9 @@ public final class RTMKeyHandlerServer {
         if (keyCode == RTMCore.KEY_SNEAK) {
             this.setVehicleState(player, -1);
         } else if (keyCode == RTMCore.KEY_Horn) {
-            this.playSound(player, sound, 6F, false);
+            this.playSound(player, sound, 1.0F, false, RTMConfig.trainHornSoundRange);
         } else if (keyCode == RTMCore.KEY_Chime) {
-            this.playSound(player, sound, 1.0F, true);
+            this.playSound(player, sound, 1.0F, true, 16.0F);
         } else if (keyCode == RTMCore.KEY_ControlPanel) {
             player.openGui(RTMCore.instance, RTMCore.guiIdTrainControlPanel, player.worldObj, player.ridingEntity.getEntityId(), 0, 0);
         } else if (keyCode == RTMCore.KEY_Fire) {
@@ -53,15 +54,15 @@ public final class RTMKeyHandlerServer {
         }
     }
 
-    private void playSound(EntityPlayer player, String sound, float vol, boolean allCar) {
+    private void playSound(EntityPlayer player, String sound, float vol, boolean allCar, float range) {
         EntityTrainBase train = this.getRidingTrain(player);
         if (train != null) {
             String[] sa = sound.split(":");
             if (sa.length == 2) {
                 if (allCar && train.getFormation() != null) {
-                    train.getFormation().getTrainStream().forEach(entryTrain -> RTMCore.proxy.playSound(entryTrain, new ResourceLocation(sa[0], sa[1]), vol, 1.0F));
+                    train.getFormation().getTrainStream().forEach(entryTrain -> RTMCore.proxy.playSound(entryTrain, new ResourceLocation(sa[0], sa[1]), vol, 1.0F, range));
                 } else {
-                    RTMCore.proxy.playSound(train, new ResourceLocation(sa[0], sa[1]), vol, 1.0F);
+                    RTMCore.proxy.playSound(train, new ResourceLocation(sa[0], sa[1]), vol, 1.0F, range);
                 }
             }
         }

--- a/src/main/java/jp/ngt/rtm/network/PacketPlaySound.java
+++ b/src/main/java/jp/ngt/rtm/network/PacketPlaySound.java
@@ -17,22 +17,33 @@ public class PacketPlaySound extends PacketCustom implements IMessage, IMessageH
     private ResourceLocation sound;
     private float volume;
     private float pitch;
+    private float range;
 
     public PacketPlaySound() {
     }
 
     public PacketPlaySound(Entity par1, ResourceLocation par2, float par3, float par4) {
+        this(par1, par2, par3, par4, 16.0F);
+    }
+
+    public PacketPlaySound(Entity par1, ResourceLocation par2, float par3, float par4, float par5) {
         super(par1);
         this.sound = par2;
         this.volume = par3;
         this.pitch = par4;
+        this.range = par5;
     }
 
-    public PacketPlaySound(TileEntity par1, ResourceLocation sound2, float par3, float par4) {
+    public PacketPlaySound(TileEntity par1, ResourceLocation par2, float par3, float par4) {
+        this(par1, par2, par3, par4, 16.0F);
+    }
+
+    public PacketPlaySound(TileEntity par1, ResourceLocation sound2, float par3, float par4, float par5) {
         super(par1);
         this.sound = sound2;
         this.volume = par3;
         this.pitch = par4;
+        this.range = par5;
     }
 
     @Override
@@ -42,6 +53,7 @@ public class PacketPlaySound extends PacketCustom implements IMessage, IMessageH
         ByteBufUtils.writeUTF8String(buffer, this.sound.getResourcePath());
         buffer.writeFloat(this.volume);
         buffer.writeFloat(this.pitch);
+        buffer.writeFloat(this.range);
     }
 
     @Override
@@ -52,6 +64,7 @@ public class PacketPlaySound extends PacketCustom implements IMessage, IMessageH
         this.sound = new ResourceLocation(s1, s2);
         this.volume = buffer.readFloat();
         this.pitch = buffer.readFloat();
+        this.range = buffer.readFloat();
     }
 
     @Override
@@ -60,12 +73,12 @@ public class PacketPlaySound extends PacketCustom implements IMessage, IMessageH
         if (message.forEntity()) {
             Entity entity = message.getEntity(world);
             if (entity != null) {
-                RTMCore.proxy.playSound(entity, message.sound, message.volume, message.pitch);
+                RTMCore.proxy.playSound(entity, message.sound, message.volume, message.pitch, message.range);
             }
         } else {
             TileEntity entity = message.getTileEntity(world);
             if (entity != null) {
-                RTMCore.proxy.playSound(entity, message.sound, message.volume, message.pitch);
+                RTMCore.proxy.playSound(entity, message.sound, message.volume, message.pitch, message.range);
             }
         }
         return null;

--- a/src/main/java/jp/ngt/rtm/sound/MovingSoundCustom.java
+++ b/src/main/java/jp/ngt/rtm/sound/MovingSoundCustom.java
@@ -1,0 +1,49 @@
+package jp.ngt.rtm.sound;
+
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+import jp.ngt.rtm.RTMConfig;
+import net.minecraft.client.audio.MovingSound;
+import net.minecraft.util.ResourceLocation;
+
+@SideOnly(Side.CLIENT)
+public abstract class MovingSoundCustom<T> extends MovingSound {
+    protected final T entity;
+    private float prevVolume = -1.0F;
+    private float prevPitch = -1.0F;
+
+    public MovingSoundCustom(T entity, ResourceLocation sound, boolean repeat, float range) {
+        super(sound);
+        this.entity = entity;
+        this.repeat = repeat;
+        this.field_147665_h = 0;
+        this.field_147666_i = AttenuationType.LINEAR;
+        this.volume = range / 16.0F;
+    }
+
+    @Override
+    public void update() {
+        if (this.prevVolume >= 0.0F) {
+            this.volume = this.prevVolume;
+            this.prevVolume = -1.0F;
+        }
+
+        if (this.prevPitch >= 0.0F) {
+            this.field_147663_c = this.prevPitch;
+            this.prevPitch = -1.0F;
+        }
+    }
+
+    public void stop() {
+        this.donePlaying = true;
+    }
+
+    public void setVolume(float par1) {
+        float vol = par1 * RTMConfig.trainSoundVol;
+        this.prevVolume = Math.max(vol, 0.0F);
+    }
+
+    public void setPitch(float par1) {
+        this.prevPitch = Math.max(par1, 0.0F);
+    }
+}

--- a/src/main/java/jp/ngt/rtm/sound/MovingSoundEntity.java
+++ b/src/main/java/jp/ngt/rtm/sound/MovingSoundEntity.java
@@ -2,23 +2,18 @@ package jp.ngt.rtm.sound;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
-import jp.ngt.rtm.RTMConfig;
-import net.minecraft.client.audio.MovingSound;
 import net.minecraft.entity.Entity;
 import net.minecraft.util.ResourceLocation;
 
 @SideOnly(Side.CLIENT)
-public class MovingSoundEntity extends MovingSound {
-    protected final Entity entity;
-    private float prevVolume = -1.0F;
-    private float prevPitch = -1.0F;
+public class MovingSoundEntity extends MovingSoundCustom<Entity> {
 
     public MovingSoundEntity(Entity par1Entity, ResourceLocation par2Sound, boolean par3Repeat) {
-        super(par2Sound);
-        this.entity = par1Entity;
-        this.repeat = par3Repeat;
-        this.field_147665_h = 0;
-        this.field_147666_i = AttenuationType.LINEAR;
+        this(par1Entity, par2Sound, par3Repeat, 16.0F);
+    }
+
+    public MovingSoundEntity(Entity par1Entity, ResourceLocation par2Sound, boolean par3Repeat, float range) {
+        super(par1Entity, par2Sound, par3Repeat, range);
     }
 
     @Override
@@ -32,30 +27,6 @@ public class MovingSoundEntity extends MovingSound {
         this.yPosF = (float) this.entity.posY;
         this.zPosF = (float) this.entity.posZ;
 
-        if (this.prevVolume >= 0.0F) {
-            this.volume = this.prevVolume;
-            this.prevVolume = -1.0F;
-        }
-
-        if (this.prevPitch >= 0.0F) {
-            this.field_147663_c = this.prevPitch;
-            this.prevPitch = -1.0F;
-        }
-        //this.volume = RTMCore.trainSoundVol;
-    }
-
-    public void stop() {
-        this.donePlaying = true;
-    }
-
-    public void setVolume(float par1) {
-        float vol = par1 * RTMConfig.trainSoundVol;
-        //this.prevVolume = vol < 0.0F ? 0.0F : (vol > 2.0F ? 2.0F : vol);
-        this.prevVolume = Math.max(vol, 0.0F);
-    }
-
-    public void setPitch(float par1) {
-        //this.prevPitch = par1 < 0.0F ? 0.0F : (par1 > 2.0F ? 2.0F : par1);
-        this.prevPitch = Math.max(par1, 0.0F);
+        super.update();
     }
 }

--- a/src/main/java/jp/ngt/rtm/sound/MovingSoundTileEntity.java
+++ b/src/main/java/jp/ngt/rtm/sound/MovingSoundTileEntity.java
@@ -2,23 +2,18 @@ package jp.ngt.rtm.sound;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
-import jp.ngt.rtm.RTMConfig;
-import net.minecraft.client.audio.MovingSound;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ResourceLocation;
 
 @SideOnly(Side.CLIENT)
-public class MovingSoundTileEntity extends MovingSound {
-    protected final TileEntity entity;
-    private float prevVolume = -1.0F;
-    private float prevPitch = -1.0F;
+public class MovingSoundTileEntity extends MovingSoundCustom<TileEntity> {
 
     public MovingSoundTileEntity(TileEntity par1Entity, ResourceLocation par2Sound, boolean par3Repeat) {
-        super(par2Sound);
-        this.entity = par1Entity;
-        this.repeat = par3Repeat;
-        this.field_147665_h = 0;
-        this.field_147666_i = AttenuationType.LINEAR;//減衰率, NONEで音量変わらず
+        this(par1Entity, par2Sound, par3Repeat, 16.0F);
+    }
+
+    public MovingSoundTileEntity(TileEntity par1Entity, ResourceLocation par2Sound, boolean par3Repeat, float range) {
+        super(par1Entity, par2Sound, par3Repeat, range);
 
         this.xPosF = (float) this.entity.xCoord + 0.5F;
         this.yPosF = (float) this.entity.yCoord + 0.5F;
@@ -32,27 +27,6 @@ public class MovingSoundTileEntity extends MovingSound {
             return;
         }
 
-        if (this.prevVolume >= 0.0F) {
-            this.volume = this.prevVolume;
-            this.prevVolume = -1.0F;
-        }
-
-        if (this.prevPitch >= 0.0F) {
-            this.field_147663_c = this.prevPitch;
-            this.prevPitch = -1.0F;
-        }
-    }
-
-    public void stop() {
-        this.donePlaying = true;
-    }
-
-    public void setVolume(float par1) {
-        float vol = par1 * RTMConfig.trainSoundVol;
-        this.prevVolume = Math.max(vol, 0.0F);
-    }
-
-    public void setPitch(float par1) {
-        this.prevPitch = Math.max(par1, 0.0F);
+        super.update();
     }
 }

--- a/src/main/java/jp/ngt/rtm/sound/MovingSoundTrain.java
+++ b/src/main/java/jp/ngt/rtm/sound/MovingSoundTrain.java
@@ -9,7 +9,11 @@ import net.minecraft.util.ResourceLocation;
 @SideOnly(Side.CLIENT)
 public class MovingSoundTrain extends MovingSoundVehicle {
     public MovingSoundTrain(EntityTrainBase train, ResourceLocation sound, boolean par3, boolean par4) {
-        super(train, sound, par3, par4);
+        this(train, sound, par3, par4, 16.0F);
+    }
+
+    public MovingSoundTrain(EntityTrainBase train, ResourceLocation sound, boolean par3, boolean par4, float range) {
+        super(train, sound, par3, par4, range);
     }
 
     @Override

--- a/src/main/java/jp/ngt/rtm/sound/MovingSoundVehicle.java
+++ b/src/main/java/jp/ngt/rtm/sound/MovingSoundVehicle.java
@@ -10,13 +10,17 @@ public class MovingSoundVehicle extends MovingSoundEntity {
     protected boolean changePitch;
 
     /**
-     * @param train
+     * @param vehicle
      * @param sound
-     * @param par3  リピート
-     * @param par4  ピッチ変更
+     * @param par3    リピート
+     * @param par4    ピッチ変更
      */
     public MovingSoundVehicle(EntityVehicleBase vehicle, ResourceLocation sound, boolean par3, boolean par4) {
-        super(vehicle, sound, par3);
+        this(vehicle, sound, par3, par4, 16.0F);
+    }
+
+    public MovingSoundVehicle(EntityVehicleBase vehicle, ResourceLocation sound, boolean par3, boolean par4, float range) {
+        super(vehicle, sound, par3, range);
         this.changePitch = par4;
     }
 

--- a/src/main/java/jp/ngt/rtm/sound/SoundPlayer.java
+++ b/src/main/java/jp/ngt/rtm/sound/SoundPlayer.java
@@ -2,6 +2,7 @@ package jp.ngt.rtm.sound;
 
 import jp.ngt.ngtlib.util.NGTUtil;
 import jp.ngt.ngtlib.util.NGTUtilClient;
+import jp.ngt.rtm.RTMConfig;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ResourceLocation;
 
@@ -31,9 +32,7 @@ public class SoundPlayer {
             if (this.sound != null) {
                 this.stopSound();
             }
-            this.sound = new MovingSoundTileEntity(tile, src, repeat);
-            this.sound.setVolume(4.0F);
-            this.sound.update();
+            this.sound = new MovingSoundTileEntity(tile, src, repeat, RTMConfig.crossingGateSoundRange);
             NGTUtilClient.playSound(this.sound);
         }
 

--- a/src/main/java/jp/ngt/rtm/sound/SoundUpdaterVehicle.java
+++ b/src/main/java/jp/ngt/rtm/sound/SoundUpdaterVehicle.java
@@ -3,6 +3,7 @@ package jp.ngt.rtm.sound;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import jp.ngt.ngtlib.io.ScriptUtil;
+import jp.ngt.rtm.RTMConfig;
 import jp.ngt.rtm.entity.train.EntityTrainBase;
 import jp.ngt.rtm.entity.vehicle.EntityVehicleBase;
 import jp.ngt.rtm.entity.vehicle.IUpdateVehicle;
@@ -114,15 +115,11 @@ public class SoundUpdaterVehicle implements IUpdateVehicle {
         MovingSoundVehicle sound = this.getPlayingSound(domain, path);
         boolean flag = (sound == null);
         if (flag) {
-            if (volume == 0) {
-                return;
-            }
             ResourceLocation resource = new ResourceLocation(domain, path);
-            sound = new MovingSoundVehicle(this.theVehicle, resource, repeat, false);
+            sound = new MovingSoundVehicle(this.theVehicle, resource, repeat, false, RTMConfig.trainRunningSoundRange);
         }
         sound.setVolume(volume);
         sound.setPitch(pitch);
-        sound.update();
 
         if (flag) {
             this.theSoundHandler.playSound(sound);


### PR DESCRIPTION
closes #345
#311の実装の修正
Configから設定可能に
走行音のデフォルトでの可聴範囲を48ブロックに拡張
踏切音のデフォルトでの可聴範囲を32ブロックに変更
台車ジョイント音のデフォルトでの可聴範囲を48ブロックに変更