### PR TITLE
fix(mcte/editor) editor is unusable when re-join SMP server

### DIFF
--- a/src/main/java/jp/ngt/mcte/MCTE.java
+++ b/src/main/java/jp/ngt/mcte/MCTE.java
@@ -19,6 +19,7 @@ import cpw.mods.fml.relauncher.Side;
 import jp.kaiz.kaizpatch.KaizPatchX;
 import jp.ngt.mcte.block.*;
 import jp.ngt.mcte.block.RSPort.PortType;
+import jp.ngt.mcte.editor.EditorManager;
 import jp.ngt.mcte.editor.EntityEditor;
 import jp.ngt.mcte.gui.MCTEGuiHandler;
 import jp.ngt.mcte.item.ItemEditor;
@@ -152,5 +153,6 @@ public class MCTE {
     @EventHandler
     public void handleServerStarting(FMLServerStartingEvent event) {
         event.registerServerCommand(new CommandMCTE());
+        EditorManager.INSTANCE.removeAll();
     }
 }

--- a/src/main/java/jp/ngt/mcte/editor/EditorManager.java
+++ b/src/main/java/jp/ngt/mcte/editor/EditorManager.java
@@ -34,7 +34,9 @@ public class EditorManager {
 
     public void removeAll() {
         NGTLog.sendChatMessageToAll("Clear %s Editors", this.editorMap.size());
-        this.editorMap.forEach((key, value) -> value.getEntity().setDead());
+        for (Entry<String, Editor> entry : this.editorMap.entrySet()) {
+            entry.getValue().getEntity().setDead();
+        }
         this.editorMap.clear();
     }
 

--- a/src/main/java/jp/ngt/mcte/editor/EntityEditor.java
+++ b/src/main/java/jp/ngt/mcte/editor/EntityEditor.java
@@ -99,7 +99,7 @@ public class EntityEditor extends Entity implements IInventory {
         }
 
         if (!this.worldObj.isRemote) {
-            if (this.getPlayer() == null) {
+            if (this.getPlayer() == null || !this.worldObj.playerEntities.contains(this.getPlayer())) {
                 this.setDead();
             }
         }


### PR DESCRIPTION
closes #343 
SMPで再ログイン時にエディターが使えなくなる問題を修正