### PR TITLE
chore: use ForgeGradle 1.2-1.1.x

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath('com.anatawa12.forge:ForgeGradle:1.2-1.0.11') {
+        classpath('com.anatawa12.forge:ForgeGradle:1.2-1.1.+') {
             changing = true
         }
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"


### PR DESCRIPTION
I've released ForgeGradle 1.2-1.1.x which includes Gradle 8.x support.