### PR TITLE
fix: NPE when loading old npc models(buttonTexture is null)

### DIFF
--- a/src/main/java/jp/ngt/rtm/modelpack/modelset/ModelSetNPCClient.java
+++ b/src/main/java/jp/ngt/rtm/modelpack/modelset/ModelSetNPCClient.java
@@ -32,7 +32,11 @@ public class ModelSetNPCClient extends ModelSetNPC implements IModelSetClient {
         } else {
             this.modelObj = new ModelObject(par1.model, this, null);
         }
-        this.buttonTexture = ModelPackManager.INSTANCE.getResource(par1.buttonTexture);
+        if (par1.buttonTexture != null) {
+            this.buttonTexture = ModelPackManager.INSTANCE.getResource(par1.buttonTexture);
+        } else {
+            this.buttonTexture = ModelPackManager.INSTANCE.getResource("textures/npc/hoge.png");
+        }
     }
 
     @Override


### PR DESCRIPTION
古いNPCモデル(buttonTextureがnull)をロードした際にクラッシュする問題を修正