### PR TITLE
Add texture name on railroad sign gui

### DIFF
--- a/src/main/java/jp/ngt/rtm/gui/GuiButtonSelectTexture.java
+++ b/src/main/java/jp/ngt/rtm/gui/GuiButtonSelectTexture.java
@@ -43,6 +43,39 @@ public class GuiButtonSelectTexture extends GuiButton {
         GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
         mc.getTextureManager().bindTexture(this.property.getTexture());
         this.draw();
+
+        // Draw texture name
+        int textureYPosition = this.yPosition + this.height + 16;
+        String textureName = property.displayName;
+        int stringWidth = mc.fontRenderer.getStringWidth(textureName);
+        int charWidth = mc.fontRenderer.getCharWidth('A');
+
+        if (stringWidth > this.width) {
+            StringBuilder newTextureNameBuilder = new StringBuilder();
+            int currentWidth = 0;
+
+            for (int i = 0; i < textureName.length(); i++) {
+                char c = textureName.charAt(i);
+
+                currentWidth += charWidth;
+
+                if (currentWidth > width) {
+                    newTextureNameBuilder.append("\n");
+                    currentWidth = charWidth;
+                }
+
+                newTextureNameBuilder.append(c);
+            }
+
+            textureName = newTextureNameBuilder.toString();
+        }
+
+        String[] splittedText = textureName.split("\n");
+
+        for (int i = 0; i < splittedText.length; i++) {
+            mc.fontRenderer.drawString(splittedText[i], this.xPosition, textureYPosition + (mc.fontRenderer.FONT_HEIGHT * i), 16777215);
+        }
+
     	/*int k = this.getHoverState(this.field_146123_n);
     	if(k == 2)
         {

--- a/src/main/java/jp/ngt/rtm/gui/GuiSelectTexture.java
+++ b/src/main/java/jp/ngt/rtm/gui/GuiSelectTexture.java
@@ -20,6 +20,7 @@ public class GuiSelectTexture extends GuiScreenCustom {
     private int currentScroll;
     private int prevScroll;
     private int uCount, vCount;
+    private final int SPACING_TEXT_Y = 64;
 
     public GuiSelectTexture(ITextureHolder par1) {
         this.holder = par1;
@@ -57,7 +58,7 @@ public class GuiSelectTexture extends GuiScreenCustom {
                 int w = (int) (prop.width * f0);
                 int h = (int) (prop.height * f0);
                 int xPos = x * u + ((x - w) / 2) + offsetX;
-                int yPos = y * v + ((y - h) / 2);
+                int yPos = (y * v + (v * this.SPACING_TEXT_Y)) + ((y - h) / 2);
                 this.buttonList.add(new GuiButtonSelectTexture(index, xPos, yPos, w, h, prop));
             }
         }

--- a/src/main/java/jp/ngt/rtm/modelpack/texture/TextureProperty.java
+++ b/src/main/java/jp/ngt/rtm/modelpack/texture/TextureProperty.java
@@ -15,7 +15,12 @@ public abstract class TextureProperty {
 
     protected ResourceLocation resource;
 
+    public String displayName;
+
     protected void init() {
+        if (this.texture != null) {
+            this.displayName = this.texture.replace("textures/signboard/", "").replace(".png", "");
+        }
     }
 
     public ResourceLocation getTexture() {


### PR DESCRIPTION
With the old Railroad Sign GUI, it was hard to tell which image was which when there were many similarly shaped images.

We've improved it to display the texutre name as shown in the image below.

![CleanShot 2024-09-01 at 15 10 21@2x](https://github.com/user-attachments/assets/c95fb0d2-05d5-47a2-a419-8c41cc1939a8)
