### PR TITLE
架線のワールド単位での管理

### DIFF
--- a/src/main/java/jp/ngt/rtm/electric/Connection.java
+++ b/src/main/java/jp/ngt/rtm/electric/Connection.java
@@ -105,11 +105,8 @@ public class Connection {
                     this.connectedObject = TileEntityElectricalWiring.getWireEntity(world, x, y, z);
                     return (TileEntityElectricalWiring) this.connectedObject;
                 } else {
-                    TileEntity te = world.getTileEntity(this.x, this.y, this.z);
-                    if (te instanceof TileEntityElectricalWiring) {
-                        this.connectedObject = te;
-                        return (TileEntityElectricalWiring) this.connectedObject;
-                    }
+                    this.connectedObject = ElectricalWiringManager.get(world).getTile(this.x, this.y, this.z);
+                    return (TileEntityElectricalWiring) this.connectedObject;
                 }
             }
         }

--- a/src/main/java/jp/ngt/rtm/electric/ElectricalWiringManager.java
+++ b/src/main/java/jp/ngt/rtm/electric/ElectricalWiringManager.java
@@ -1,0 +1,110 @@
+package jp.ngt.rtm.electric;
+
+import jp.ngt.rtm.electric.Connection.ConnectionType;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.world.World;
+
+import java.util.*;
+
+public class ElectricalWiringManager {
+    private static final Map<Integer, ElectricalWiringManager> INSTANCES = new HashMap<>();
+
+    private final Map<Long, TileEntityElectricalWiring> registry = new HashMap<>();
+
+    public static ElectricalWiringManager get(World world) {
+        int dimId = world.provider.dimensionId;
+        ElectricalWiringManager manager = INSTANCES.get(dimId);
+        if (manager == null) {
+            manager = new ElectricalWiringManager();
+            INSTANCES.put(dimId, manager);
+        }
+        return manager;
+    }
+
+    public static void onWorldUnload(World world) {
+        INSTANCES.remove(world.provider.dimensionId);
+    }
+
+    public void register(TileEntityElectricalWiring tile) {
+        registry.put(pack(tile.xCoord, tile.yCoord, tile.zCoord), tile);
+    }
+
+    public void unregister(TileEntityElectricalWiring tile) {
+        registry.remove(pack(tile.xCoord, tile.yCoord, tile.zCoord));
+    }
+
+    /**
+     * ノード削除。当該座標のタイルを registry から除き、他の全タイルからこの座標への接続を切断する。
+     * ブロック破壊・エンティティ死亡時に呼ぶ。
+     */
+    public void onNodeRemoved(int x, int y, int z) {
+        registry.remove(pack(x, y, z));
+        for (TileEntityElectricalWiring tile : new ArrayList<>(registry.values())) {
+            if (tile.getConnection(x, y, z) != null) {
+                tile.setConnectionTo(x, y, z, ConnectionType.NONE, "");
+            }
+        }
+    }
+
+    /**
+     * プレイヤーへの TO_PLAYER 接続を全タイルから切断する。
+     * プレイヤーログアウト時に呼ぶ。
+     */
+    public void removePlayerConnections(EntityPlayer player) {
+        for (TileEntityElectricalWiring tile : new ArrayList<>(registry.values())) {
+            Connection c = tile.getConnection(player.getEntityId(), -1, 0);
+            if (c != null && c.type == ConnectionType.TO_PLAYER) {
+                tile.setConnectionTo(player.getEntityId(), -1, 0, ConnectionType.NONE, "");
+            }
+        }
+    }
+
+    public TileEntityElectricalWiring getTile(int x, int y, int z) {
+        return registry.get(pack(x, y, z));
+    }
+
+    /**
+     * origin からBFSで全接続ノードへ signal を伝播する。
+     * サイクルは visited セットで防止。1tick内に全ノードへ到達する。
+     */
+    public void propagateSignal(TileEntityElectricalWiring origin, int level) {
+        World world = origin.getWorldObj();
+        if (world == null || world.isRemote) return;
+
+        Set<TileEntityElectricalWiring> visited = new HashSet<>();
+        Deque<TileEntityElectricalWiring> queue = new ArrayDeque<>();
+        visited.add(origin);
+        processNode(world, origin, level, queue, visited);
+
+        while (!queue.isEmpty()) {
+            TileEntityElectricalWiring tile = queue.poll();
+            tile.onReceiveSignal(level);
+            processNode(world, tile, level, queue, visited);
+        }
+    }
+
+    private void processNode(World world, TileEntityElectricalWiring tile, int level,
+                             Deque<TileEntityElectricalWiring> queue,
+                             Set<TileEntityElectricalWiring> visited) {
+        for (Connection c : tile.getConnectionList()) {
+            if (c.type == ConnectionType.NONE || c.type == ConnectionType.TO_PLAYER) continue;
+            if (c.type == ConnectionType.DIRECT) {
+                tile.applyToDirectConnection(c, level);
+            } else if (c.type == ConnectionType.TO_ENTITY) {
+                TileEntityElectricalWiring next = TileEntityElectricalWiring.getWireEntity(world, c.x, c.y, c.z);
+                if (next != null && visited.add(next)) {
+                    queue.add(next);
+                }
+            } else { // WIRE
+                TileEntityElectricalWiring next = this.getTile(c.x, c.y, c.z);
+                if (next != null && visited.add(next)) {
+                    queue.add(next);
+                }
+            }
+        }
+    }
+
+    private static long pack(int x, int y, int z) {
+        return ((long) (x & 0x3FFFFFF) << 38) | ((long) (y & 0xFF) << 30) | (z & 0x3FFFFFFL);
+    }
+}

--- a/src/main/java/jp/ngt/rtm/electric/EntityElectricalWiring.java
+++ b/src/main/java/jp/ngt/rtm/electric/EntityElectricalWiring.java
@@ -34,9 +34,20 @@ public abstract class EntityElectricalWiring extends EntityInstalledObject {
 
         if (this.tileEW.yCoord <= 0) {
             this.setTilePos();
+            if (!this.worldObj.isRemote) {
+                ElectricalWiringManager.get(this.worldObj).register(this.tileEW);
+            }
         }
 
         this.tileEW.updateEntity();
+    }
+
+    @Override
+    public void setDead() {
+        if (!this.worldObj.isRemote && this.tileEW.yCoord > 0) {
+            ElectricalWiringManager.get(this.worldObj).onNodeRemoved(this.tileEW.xCoord, this.tileEW.yCoord, this.tileEW.zCoord);
+        }
+        super.setDead();
     }
 
     private void setTilePos() {

--- a/src/main/java/jp/ngt/rtm/electric/TileEntityConnector.java
+++ b/src/main/java/jp/ngt/rtm/electric/TileEntityConnector.java
@@ -11,23 +11,12 @@ public class TileEntityConnector extends TileEntityConnectorBase {
     private int prevOutputSignal = -1;
 
     @Override
-    public void onGetElectricity(int x, int y, int z, int level, int counter) {
-        if (this.getBlockMetadata() < METADATA)//in
-        {
-            super.onGetElectricity(x, y, z, level, counter);
-        }
-    }
-
-    @Override
-    protected void sendElectricity(Connection connection, int level, int counter) {
-        if (this.getBlockMetadata() < METADATA && connection.type == ConnectionType.DIRECT)//in
-        {
-            IProvideElectricity provider = connection.getIProvideElectricity(this.worldObj);
+    protected void applyToDirectConnection(Connection c, int level) {
+        if (this.getBlockMetadata() < METADATA) { // 入力モードのみデバイスへ転送
+            IProvideElectricity provider = c.getIProvideElectricity(this.worldObj);
             if (provider != null) {
                 provider.setElectricity(this.xCoord, this.yCoord, this.zCoord, level);
             }
-        } else {
-            super.sendElectricity(connection, level, counter);
         }
     }
 
@@ -45,16 +34,13 @@ public class TileEntityConnector extends TileEntityConnectorBase {
 
     private void checkSignalOutput() {
         Connection connection = this.getBlockConnection();
-        if (connection == null) {
-            return;
-        }
+        if (connection == null) return;
 
         IProvideElectricity provider = connection.getIProvideElectricity(this.worldObj);
         if (provider != null) {
             int level = provider.getElectricity();
             if (level != this.prevOutputSignal) {
-                //this.onGetElectricity(connection.x, connection.y, connection.z, level, 0);
-                this.sendElectricityToAll(level);
+                ElectricalWiringManager.get(this.worldObj).propagateSignal(this, level);
                 this.prevOutputSignal = level;
             }
         }

--- a/src/main/java/jp/ngt/rtm/electric/TileEntityConnectorBase.java
+++ b/src/main/java/jp/ngt/rtm/electric/TileEntityConnectorBase.java
@@ -17,6 +17,7 @@ public abstract class TileEntityConnectorBase extends TileEntityElectricalWiring
     private String modelName = "";
     private ModelSetConnector myModelSet;
     public Vec3 wirePos = Vec3.ZERO;
+    private int cachedBlockMeta = -1;
 
     public TileEntityConnectorBase() {
     }
@@ -27,6 +28,9 @@ public abstract class TileEntityConnectorBase extends TileEntityElectricalWiring
 
     @Override
     public void readFromNBT(NBTTagCompound nbt) {
+        if (nbt.hasKey("blockMeta")) {
+            this.cachedBlockMeta = nbt.getInteger("blockMeta");
+        }
         super.readFromNBT(nbt);
         String name;
         if (nbt.hasKey("ModelName") || !this.hasWorldObj()) {
@@ -46,6 +50,9 @@ public abstract class TileEntityConnectorBase extends TileEntityElectricalWiring
         }
         nbt.setString("ModelName", this.modelName);
         nbt.setTag("State", this.getResourceState().writeToNBT());
+        if (this.hasWorldObj()) {
+            nbt.setInteger("blockMeta", this.getBlockMetadata());
+        }
     }
 
     @Override
@@ -82,7 +89,7 @@ public abstract class TileEntityConnectorBase extends TileEntityElectricalWiring
             cfg = this.getModelSet().getConfig();
         }
         Vec3 vec = PooledVec3.create(cfg.wirePos[0], cfg.wirePos[1], cfg.wirePos[2]);
-        int meta = this.getBlockMetadata();
+        int meta = this.cachedBlockMeta >= 0 ? this.cachedBlockMeta : this.getBlockMetadata();
         switch (meta) {
             case 0:
                 vec = vec.rotateAroundZ((180.0F));

--- a/src/main/java/jp/ngt/rtm/electric/TileEntityDummyEW.java
+++ b/src/main/java/jp/ngt/rtm/electric/TileEntityDummyEW.java
@@ -13,12 +13,8 @@ public class TileEntityDummyEW extends TileEntityElectricalWiring {
     }
 
     @Override
-    public void onGetElectricity(int x, int y, int z, int level, int counter) {
-        super.onGetElectricity(x, y, z, level, counter);
-
-        if (!(x == this.xCoord && y == this.yCoord && z == this.zCoord)) {
-            this.entityEW.setElectricity(level);
-        }
+    protected void onReceiveSignal(int level) {
+        this.entityEW.setElectricity(level);
     }
 
     @Override
@@ -28,7 +24,7 @@ public class TileEntityDummyEW extends TileEntityElectricalWiring {
         if (!this.worldObj.isRemote) {
             int level = this.entityEW.getElectricity();
             if (level >= 0 && level != this.prevSignal) {
-                this.onGetElectricity(this.xCoord, this.yCoord, this.zCoord, level, 0);
+                ElectricalWiringManager.get(this.worldObj).propagateSignal(this, level);
                 this.prevSignal = level;
             }
         }

--- a/src/main/java/jp/ngt/rtm/electric/TileEntityElectricalWiring.java
+++ b/src/main/java/jp/ngt/rtm/electric/TileEntityElectricalWiring.java
@@ -28,8 +28,6 @@ public abstract class TileEntityElectricalWiring extends TileEntityPlaceable {
     protected List<Connection> connections = new ArrayList<>();
 
     public boolean isActivated;
-    private int signal;
-    private int prevSignal = -1;
 
     @Override
     public void readFromNBT(NBTTagCompound nbt) {
@@ -150,63 +148,55 @@ public abstract class TileEntityElectricalWiring extends TileEntityPlaceable {
     }
 
     /**
-     * 信号受信
+     * BFS伝播でこのノードが信号を受け取ったときに呼ばれる。
+     * サブクラスでオーバーライドして処理を実装する（例: エンティティへの転送）。
      */
-    public void onGetElectricity(int x, int y, int z, int level, int counter) {
-        if (level == 0) {
-            if (this.prevSignal < 0) {
-                this.prevSignal = 0;
-            }
-        } else if (level > 0) {
-            if (level != this.prevSignal) {
-                this.prevSignal = level;
-            }
-        }
+    protected void onReceiveSignal(int level) {
     }
 
     /**
-     * 信号送信
+     * BFS伝播でDIRECT接続先へ信号を適用するときに呼ばれる。
+     * TileEntityConnector がオーバーライドして IProvideElectricity に転送する。
      */
-    protected void sendElectricity(Connection connection, int level, int counter) {
-        TileEntityElectricalWiring tile = connection.getElectricalWiring(this.worldObj);
-        if (tile != null)//counter < 128
-        {
-            tile.onGetElectricity(this.xCoord, this.yCoord, this.zCoord, level, ++counter);
+    protected void applyToDirectConnection(Connection c, int level) {
+    }
+
+    @Override
+    public void validate() {
+        super.validate();
+        if (this.worldObj != null && !this.worldObj.isRemote && this.isBlockTile()) {
+            ElectricalWiringManager.get(this.worldObj).register(this);
         }
     }
 
-    /**
-     * 全てに信号送信
-     */
-    protected void sendElectricityToAll(int level) {
-        this.connections.stream().filter(connection -> connection.type != ConnectionType.NONE).forEach(connection -> this.sendElectricity(connection, level, 0));
+    @Override
+    public void invalidate() {
+        if (this.worldObj != null && !this.worldObj.isRemote && this.isBlockTile()) {
+            ElectricalWiringManager.get(this.worldObj).onNodeRemoved(this.xCoord, this.yCoord, this.zCoord);
+        }
+        super.invalidate();
+    }
+
+    @Override
+    public void onChunkUnload() {
+        if (this.worldObj != null && !this.worldObj.isRemote && this.isBlockTile()) {
+            ElectricalWiringManager.get(this.worldObj).unregister(this);
+        }
+        super.onChunkUnload();
     }
 
     @Override
     public void updateEntity() {
         super.updateEntity();
 
-        if (this.worldObj.isRemote) {
-            if (this.isActivated) {
-                Random random = this.worldObj.rand;
-                IntStream.range(0, 3).forEach(d -> {
-                    double d1 = (float) this.xCoord + random.nextFloat();
-                    double d2 = (float) this.yCoord + random.nextFloat();
-                    double d3 = (float) this.zCoord + random.nextFloat();
-                    this.worldObj.spawnParticle("reddust", d1, d2, d3, 0.0D, 0.0D, 0.0D);
-                });
-            }
-        } else {
-            //接続が有効かを確認
-            List<Connection> list = new ArrayList<>(this.connections);
-            list.stream().filter(connection -> !connection.isAvailable(this.worldObj) || connection.type == ConnectionType.NONE).forEach(connection -> this.setConnectionTo(connection.x, connection.y, connection.z, ConnectionType.NONE, ""));
-
-            //信号の処理
-            if (this.prevSignal >= 0 && this.prevSignal != this.signal) {
-                this.signal = this.prevSignal;
-                this.sendElectricityToAll(this.signal);
-            }
-            this.prevSignal = -1;
+        if (this.worldObj.isRemote && this.isActivated) {
+            Random random = this.worldObj.rand;
+            IntStream.range(0, 3).forEach(d -> {
+                double d1 = (float) this.xCoord + random.nextFloat();
+                double d2 = (float) this.yCoord + random.nextFloat();
+                double d3 = (float) this.zCoord + random.nextFloat();
+                this.worldObj.spawnParticle("reddust", d1, d2, d3, 0.0D, 0.0D, 0.0D);
+            });
         }
     }
 
@@ -373,7 +363,9 @@ public abstract class TileEntityElectricalWiring extends TileEntityPlaceable {
      * ブロック破壊時に呼ばれる
      */
     public void onBlockBreaked() {
-        this.connections.forEach(connection -> this.sendElectricity(connection, 0, 0));
+        if (this.worldObj != null && !this.worldObj.isRemote) {
+            ElectricalWiringManager.get(this.worldObj).propagateSignal(this, 0);
+        }
     }
 
     @Override

--- a/src/main/java/jp/ngt/rtm/event/RTMEventHandler.java
+++ b/src/main/java/jp/ngt/rtm/event/RTMEventHandler.java
@@ -11,6 +11,7 @@ import cpw.mods.fml.common.network.FMLNetworkEvent.ServerConnectionFromClientEve
 import jp.ngt.ngtlib.util.NGTUtil;
 import jp.ngt.rtm.RTMConfig;
 import jp.ngt.rtm.RTMCore;
+import jp.ngt.rtm.electric.ElectricalWiringManager;
 import jp.ngt.rtm.entity.train.EntityTrainBase;
 import jp.ngt.rtm.entity.train.parts.EntityFloor;
 import jp.ngt.rtm.entity.train.util.FormationManager;
@@ -59,6 +60,14 @@ public final class RTMEventHandler {
             event.player.mountEntity(null);
             ((EntityTrainBase) ridingEntity).setEBNotch();
         }
+        if (!event.player.worldObj.isRemote) {
+            ElectricalWiringManager.get(event.player.worldObj).removePlayerConnections(event.player);
+        }
+    }
+
+    @SubscribeEvent
+    public void onUnloadWorld(WorldEvent.Unload event) {
+        ElectricalWiringManager.onWorldUnload(event.world);
     }
 
     @SubscribeEvent


### PR DESCRIPTION
TileEntity Tickで分散して信号レベルの管理を行っていたのを、ワールド単位で一括で処理するようにする