### PR TITLE
feat: train protection plugin system

### DIFF
--- a/src/main/java/jp/ngt/rtm/ClientProxy.java
+++ b/src/main/java/jp/ngt/rtm/ClientProxy.java
@@ -90,6 +90,7 @@ public class ClientProxy extends CommonProxy {
         RenderingRegistry.registerEntityRenderingHandler(EntityFloor.class, new RenderSeat());
         RenderingRegistry.registerEntityRenderingHandler(EntityATC.class, RenderEntityInstalledObject.INSTANCE);
         RenderingRegistry.registerEntityRenderingHandler(EntityTrainDetector.class, RenderEntityInstalledObject.INSTANCE);
+        RenderingRegistry.registerEntityRenderingHandler(EntityTransponder.class, RenderEntityInstalledObject.INSTANCE);
         RenderingRegistry.registerEntityRenderingHandler(EntityBumpingPost.class, RenderEntityInstalledObject.INSTANCE);
         RenderingRegistry.registerEntityRenderingHandler(EntityContainer.class, new RenderContainer());
         RenderingRegistry.registerEntityRenderingHandler(EntityArtillery.class, new RenderArtillery());

--- a/src/main/java/jp/ngt/rtm/RTMEntity.java
+++ b/src/main/java/jp/ngt/rtm/RTMEntity.java
@@ -26,6 +26,7 @@ public final class RTMEntity {
         EntityRegistry.registerModEntity(EntityMotorman.class, "RTM.E.Motorman", getNextId(), mod, RANGE, 3, true);
         EntityRegistry.registerModEntity(EntityATC.class, "RTM.E.ATC", getNextId(), mod, 160, FREQ_INSTALLED, false);
         EntityRegistry.registerModEntity(EntityTrainDetector.class, "RTM.E.TrainDetector", getNextId(), mod, 160, FREQ_INSTALLED, false);
+        EntityRegistry.registerModEntity(EntityTransponder.class, "RTM.E.Transponder", getNextId(), mod, 160, FREQ_INSTALLED, false);
         EntityRegistry.registerModEntity(EntityContainer.class, "RTM.E.Container", getNextId(), mod, 160, FREQ_VEHICLE, false);
         EntityRegistry.registerModEntity(EntityArtillery.class, "RTM.E.Artillery", getNextId(), mod, 160, FREQ_VEHICLE, false);
         EntityRegistry.registerModEntity(EntityBullet.class, "RTM.E.Bullet", getNextId(), mod, 256, 3, true);

--- a/src/main/java/jp/ngt/rtm/RTMPacket.java
+++ b/src/main/java/jp/ngt/rtm/RTMPacket.java
@@ -17,6 +17,8 @@ public final class RTMPacket {
         registerPacket(PacketNoticeHandlerServer.class, PacketNotice.class, Side.SERVER);
         registerPacket(PacketDataMap.class, PacketDataMap.class, Side.CLIENT);
         registerPacket(PacketDataMap.class, PacketDataMap.class, Side.SERVER);
+        registerPacket(PacketTrainProtectionPluginList.class, PacketTrainProtectionPluginList.class, Side.CLIENT);
+        registerPacket(PacketTrainProtectionPluginState.class, PacketTrainProtectionPluginState.class, Side.CLIENT);
         registerPacket(PacketRTMKey.class, PacketRTMKey.class, Side.SERVER);
         registerPacket(PacketSelectModel.class, PacketSelectModel.class, Side.SERVER);
         registerPacket(PacketWire.class, PacketWire.class, Side.CLIENT);

--- a/src/main/java/jp/ngt/rtm/electric/MachineType.java
+++ b/src/main/java/jp/ngt/rtm/electric/MachineType.java
@@ -9,5 +9,6 @@ public enum MachineType {
     BumpingPost,
     Antenna_Send,
     Antenna_Receive,
-    Speaker
+    Speaker,
+    Transponder
 }

--- a/src/main/java/jp/ngt/rtm/entity/EntityInstalledObject.java
+++ b/src/main/java/jp/ngt/rtm/entity/EntityInstalledObject.java
@@ -238,6 +238,10 @@ public abstract class EntityInstalledObject extends Entity implements IModelSele
 
     protected abstract String getDefaultName();
 
+    protected ScriptExecuter getScriptExecuter() {
+        return this.executer;
+    }
+
     @Override
     public ItemStack getPickedResult(MovingObjectPosition target) {
         ItemStack itemStack = this.getItem();

--- a/src/main/java/jp/ngt/rtm/entity/EntityTransponder.kt
+++ b/src/main/java/jp/ngt/rtm/entity/EntityTransponder.kt
@@ -1,0 +1,109 @@
+package jp.ngt.rtm.entity
+
+import jp.ngt.rtm.RTMCore
+import jp.ngt.rtm.RTMItem
+import jp.ngt.rtm.entity.train.EntityTrainBase
+import jp.ngt.rtm.item.ItemInstalledObject.IstlObjType
+import jp.ngt.rtm.modelpack.DataFormProvider
+import jp.ngt.rtm.modelpack.cfg.DataFormConfig
+import net.minecraft.entity.player.EntityPlayer
+import net.minecraft.item.ItemStack
+import net.minecraft.world.World
+import java.util.*
+import kotlin.math.abs
+
+class EntityTransponder(world: World) : EntityInstalledObject(world), DataFormProvider {
+    private val trainEntryTracker = EntryTracker<UUID>()
+
+    init {
+        setSize(1.0F, 0.0625F)
+        ignoreFrustumCheck = true
+    }
+
+    override fun onUpdate() {
+        super.onUpdate()
+        if (!worldObj.isRemote) {
+            updateTrainEntries()
+        }
+    }
+
+    private fun updateTrainEntries() {
+        val detectionBox = boundingBox.expand(0.0, EntityTrainBase.TRAIN_HEIGHT.toDouble(), 0.0)
+        val trains = worldObj
+            .getEntitiesWithinAABB(EntityTrainBase::class.java, detectionBox)
+            .filterIsInstance<EntityTrainBase>()
+        val trainsById = trains.associateBy { it.uniqueID }
+        for (entityId in trainEntryTracker.update(trainsById.keys)) {
+            val train = trainsById[entityId] ?: continue
+            val executer = scriptExecuter
+            executer.execScript(this, TRAIN_PASS_EVENT, this, train, executer)
+        }
+    }
+
+    /**
+     * 車両の進行側が、この地上子の指向方向を向いているかを返す
+     */
+    fun isTrainFacingDirection(train: EntityTrainBase): Boolean =
+        isTrainFacingTransponderDirection(rotationYaw, train.rotationYaw, train.trainDirection)
+
+    override fun interactFirst(player: EntityPlayer): Boolean {
+        if (player.isSneaking && player.currentEquippedItem == null) {
+            if (worldObj.isRemote) {
+                player.openGui(
+                    RTMCore.instance,
+                    RTMCore.guiIdSelectEntityModel.toInt(),
+                    worldObj,
+                    entityId,
+                    0,
+                    0
+                )
+            }
+            return true
+        }
+
+        if (worldObj.isRemote && dataFormConfig?.isValid == true) {
+            val pos = getPos()
+            player.openGui(
+                RTMCore.instance,
+                RTMCore.guiIdDataForm.toInt(),
+                worldObj,
+                pos[0],
+                pos[1],
+                pos[2]
+            )
+        }
+        return true
+    }
+
+    protected override fun dropItems() {
+        entityDropItem(ItemStack(RTMItem.installedObject, 1, IstlObjType.TRANSPONDER.id.toInt()), 0.0F)
+    }
+
+    override fun getSubType(): String = "Transponder"
+
+    protected override fun getDefaultName(): String = "Transponder_01"
+
+    protected override fun getItem(): ItemStack =
+        ItemStack(RTMItem.installedObject, 1, IstlObjType.TRANSPONDER.id.toInt())
+
+    override val dataFormConfig: DataFormConfig?
+        get() = modelSet.config.customForm
+
+    override val dataFormPermission: String
+        get() = RTMCore.EDIT_RAIL
+
+    companion object {
+        const val TRAIN_PASS_EVENT = "onTrainPass"
+    }
+}
+
+internal fun isTrainFacingTransponderDirection(
+    transponderYaw: Float,
+    trainYaw: Float,
+    trainDirection: Int
+): Boolean {
+    val transponderHeadingYaw = transponderYaw + 180.0F
+    val headingYaw = trainYaw + if (trainDirection == 1) 180.0F else 0.0F
+    val angleDifference = (((headingYaw - transponderHeadingYaw) % 360.0F + 540.0F) % 360.0F) - 180.0F
+    return abs(angleDifference) < 90.0F
+}

--- a/src/main/java/jp/ngt/rtm/entity/EntryTracker.kt
+++ b/src/main/java/jp/ngt/rtm/entity/EntryTracker.kt
@@ -1,0 +1,16 @@
+package jp.ngt.rtm.entity
+
+class EntryTracker<T> {
+    private var active: Set<T> = emptySet()
+
+    fun update(currentValues: Collection<T>): Set<T> {
+        val current = LinkedHashSet(currentValues)
+        val entered = current.filterTo(LinkedHashSet()) { it !in active }
+        active = current
+        return entered
+    }
+
+    fun clear() {
+        active = emptySet()
+    }
+}

--- a/src/main/java/jp/ngt/rtm/entity/train/EntityTrainBase.java
+++ b/src/main/java/jp/ngt/rtm/entity/train/EntityTrainBase.java
@@ -15,9 +15,9 @@ import jp.ngt.rtm.electric.WireManager;
 import jp.ngt.rtm.entity.npc.EntityMotorman;
 import jp.ngt.rtm.entity.npc.macro.MacroRecorder;
 import jp.ngt.rtm.entity.train.parts.EntityVehiclePart;
-import jp.ngt.rtm.entity.train.protection.ScriptTrainProtectionPlugin;
 import jp.ngt.rtm.entity.train.protection.TrainProtectionContext;
 import jp.ngt.rtm.entity.train.protection.TrainProtectionPlugin;
+import jp.ngt.rtm.entity.train.protection.TrainProtectionPluginManager;
 import jp.ngt.rtm.entity.train.util.*;
 import jp.ngt.rtm.entity.train.util.TrainState.TrainStateType;
 import jp.ngt.rtm.entity.vehicle.EntityVehicleBase;
@@ -68,7 +68,6 @@ public abstract class EntityTrainBase extends EntityVehicleBase<TrainConfig> imp
      * notch x -18
      */
     public int brakeCount = 72;
-    public int atsCount;
     private final Map<String, TrainProtectionPlugin> protectionPlugins = new LinkedHashMap<>();
     @SideOnly(Side.CLIENT)
     public int brakeAirCount;
@@ -99,6 +98,9 @@ public abstract class EntityTrainBase extends EntityVehicleBase<TrainConfig> imp
         //this.bogieController.moveTrainWithBogie(this, 0.0F);
         world.spawnEntityInWorld(this);
         this.formation = FormationManager.getInstance().createNewFormation(this);
+        if (!world.isRemote) {
+            TrainProtectionPluginManager.enableDefaultPlugins(this);
+        }
     }
 
 	/*@Override
@@ -218,7 +220,6 @@ public abstract class EntityTrainBase extends EntityVehicleBase<TrainConfig> imp
         } else//!isRemote
         {
             this.updateChunks();
-            this.updateATS();
         }
     }
 
@@ -429,16 +430,6 @@ public abstract class EntityTrainBase extends EntityVehicleBase<TrainConfig> imp
         float sw = (NGTMath.getSin(this.wave) + NGTMath.getSin(this.wave * cfg.rollVariationCoefficient)) * 0.5F;
         this.rotationRoll = roll + sw * cfg.rollWidthCoefficient;
         //できればPID制御したい
-    }
-
-    protected void updateATS() {
-        if (this.atsCount > 0) {
-            ++this.atsCount;
-            if (this.atsCount >= 100) {
-                this.stopTrain(false);
-                this.atsCount = 0;
-            }
-        }
     }
 
     @Override
@@ -1072,58 +1063,52 @@ public abstract class EntityTrainBase extends EntityVehicleBase<TrainConfig> imp
         }
     }
 
-    public void registerProtectionPlugin(String id, TrainProtectionPlugin plugin) {
+    public boolean enableProtectionPlugin(String id) {
+        TrainProtectionPlugin plugin = TrainProtectionPluginManager.getPlugin(id);
+        return this.attachProtectionPlugin(id, plugin);
+    }
+
+    private boolean attachProtectionPlugin(String id, TrainProtectionPlugin plugin) {
         if (id == null || id.isEmpty() || plugin == null) {
-            return;
+            return false;
         }
         TrainProtectionPlugin oldPlugin = this.protectionPlugins.get(id);
         if (oldPlugin == plugin) {
-            return;
+            return true;
         }
         if (oldPlugin != null) {
             this.onProtectionPluginUnregister(id, oldPlugin);
         }
         this.protectionPlugins.put(id, plugin);
         this.onProtectionPluginRegister(id, plugin);
+        return true;
     }
 
-    public void registerProtectionPlugin(String id, Object jsPlugin) {
-        if (jsPlugin instanceof TrainProtectionPlugin) {
-            this.registerProtectionPlugin(id, (TrainProtectionPlugin) jsPlugin);
-        } else {
-            this.registerProtectionPlugin(id, new ScriptTrainProtectionPlugin(jsPlugin));
-        }
-    }
-
-    public boolean unregisterProtectionPlugin(String id) {
+    public void disableProtectionPlugin(String id) {
         TrainProtectionPlugin plugin = this.protectionPlugins.remove(id);
         if (plugin != null) {
             this.onProtectionPluginUnregister(id, plugin);
-            return true;
         }
-        return false;
     }
 
     public boolean hasProtectionPlugin(String id) {
         return this.protectionPlugins.containsKey(id);
     }
 
-    public boolean onProtectionPluginATSKeyDown(EntityPlayer player) {
+    public void onProtectionPluginATSKeyDown(EntityPlayer player) {
         if (this.protectionPlugins.isEmpty()) {
-            return false;
+            return;
         }
 
-        boolean handled = false;
         for (Map.Entry<String, TrainProtectionPlugin> entry : new ArrayList<>(this.protectionPlugins.entrySet())) {
             try {
                 TrainProtectionContext context = new TrainProtectionContext(this, entry.getKey(), this.getNotch(), this.getSpeed());
-                handled |= entry.getValue().onATSKeyDown(context, player);
+                entry.getValue().onATSKeyDown(context, player);
             } catch (Exception e) {
                 NGTLog.debug("[RTM] Failed to notify train protection plugin ATS key down: " + entry.getKey());
                 e.printStackTrace();
             }
         }
-        return handled;
     }
 
     private void onProtectionPluginUnregister(String id, TrainProtectionPlugin plugin) {
@@ -1198,18 +1183,10 @@ public abstract class EntityTrainBase extends EntityVehicleBase<TrainConfig> imp
         int signal = this.getSignal();
         if (par1 > 0 && signal != -1) {
             this.setSignal2(par1);
-
-            if (par1 == 1 && this.getSpeed() > 0.0F) {
-                ++this.atsCount;
-            }
         }
     }
 
     public void setSignal2(int par1) {
-        if (par1 == -1) {
-            this.atsCount = 0;
-        }
-
         this.setByteToDataWatcher(TrainStateType.State_Signal.id, (byte) par1);
     }
 

--- a/src/main/java/jp/ngt/rtm/entity/train/EntityTrainBase.java
+++ b/src/main/java/jp/ngt/rtm/entity/train/EntityTrainBase.java
@@ -27,6 +27,7 @@ import jp.ngt.rtm.modelpack.modelset.ModelSetVehicleBase;
 import jp.ngt.rtm.modelpack.state.DataMap;
 import jp.ngt.rtm.network.PacketNotice;
 import jp.ngt.rtm.network.PacketSetTrainState;
+import jp.ngt.rtm.network.PacketTrainProtectionPluginState;
 import jp.ngt.rtm.rail.TileEntityLargeRailBase;
 import jp.ngt.rtm.rail.TileEntityLargeRailCore;
 import jp.ngt.rtm.world.IChunkLoader;
@@ -35,6 +36,7 @@ import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.nbt.NBTTagList;
 import net.minecraft.util.*;
 import net.minecraft.world.ChunkCoordIntPair;
 import net.minecraft.world.World;
@@ -46,6 +48,9 @@ import org.apache.commons.codec.binary.Base64;
 import java.util.*;
 
 public abstract class EntityTrainBase extends EntityVehicleBase<TrainConfig> implements IChunkLoader {
+    private static final String NBT_PROTECTION_PLUGINS = "TrainProtectionPlugins";
+    private static final String NBT_PROTECTION_PLUGIN_ID = "Id";
+
     private static final byte DW_Bogie0 = 21;
     private static final byte DW_Bogie1 = 22;
     private static final byte DW_FormationData = 23;
@@ -69,6 +74,7 @@ public abstract class EntityTrainBase extends EntityVehicleBase<TrainConfig> imp
      */
     public int brakeCount = 72;
     private final Map<String, TrainProtectionPlugin> protectionPlugins = new LinkedHashMap<>();
+    private final Set<String> enabledProtectionPluginIds = new LinkedHashSet<>();
     @SideOnly(Side.CLIENT)
     public int brakeAirCount;
     @SideOnly(Side.CLIENT)
@@ -143,6 +149,21 @@ public abstract class EntityTrainBase extends EntityVehicleBase<TrainConfig> imp
         nbt.setInteger("trainDir", this.getTrainDirection());
         nbt.setString("byteArray", this.dataWatcher.getWatchableObjectString(DW_ByteArray));
         nbt.setByte("cabDir", this.dataWatcher.getWatchableObjectByte(DW_CabDir));
+        this.writeProtectionPlugins(nbt);
+    }
+
+    private void writeProtectionPlugins(NBTTagCompound nbt) {
+        NBTTagList list = new NBTTagList();
+        for (String id : this.enabledProtectionPluginIds) {
+            if (id == null || id.isEmpty()) {
+                continue;
+            }
+
+            NBTTagCompound entry = new NBTTagCompound();
+            entry.setString(NBT_PROTECTION_PLUGIN_ID, id);
+            list.appendTag(entry);
+        }
+        nbt.setTag(NBT_PROTECTION_PLUGINS, list);
     }
 
     private void writeFormationData(NBTTagCompound nbt) {
@@ -169,6 +190,22 @@ public abstract class EntityTrainBase extends EntityVehicleBase<TrainConfig> imp
         this.setTrainDirection(nbt.getInteger("trainDir"));
         this.dataWatcher.updateObject(DW_ByteArray, nbt.getString("byteArray"));
         this.dataWatcher.updateObject(DW_CabDir, nbt.getByte("cabDir"));
+        this.readProtectionPlugins(nbt);
+        if (!this.worldObj.isRemote) {
+            TrainProtectionPluginManager.enableSavedPlugins(this);
+        }
+    }
+
+    private void readProtectionPlugins(NBTTagCompound nbt) {
+        this.enabledProtectionPluginIds.clear();
+        NBTTagList list = nbt.getTagList(NBT_PROTECTION_PLUGINS, 10);
+        for (int i = 0; i < list.tagCount(); ++i) {
+            NBTTagCompound entry = list.getCompoundTagAt(i);
+            String id = entry.getString(NBT_PROTECTION_PLUGIN_ID);
+            if (id != null && !id.isEmpty()) {
+                this.enabledProtectionPluginIds.add(id);
+            }
+        }
     }
 
     private void readFormationData(NBTTagCompound nbt) {
@@ -1068,12 +1105,24 @@ public abstract class EntityTrainBase extends EntityVehicleBase<TrainConfig> imp
         return this.attachProtectionPlugin(id, plugin);
     }
 
+    public void setProtectionPluginEnabled(String id, boolean enabled) {
+        if (enabled) {
+            this.enableProtectionPlugin(id);
+        } else {
+            this.disableProtectionPlugin(id);
+        }
+        if (!this.worldObj.isRemote) {
+            PacketTrainProtectionPluginState.sendToClient(this, id, this.isProtectionPluginEnabled(id));
+        }
+    }
+
     private boolean attachProtectionPlugin(String id, TrainProtectionPlugin plugin) {
         if (id == null || id.isEmpty() || plugin == null) {
             return false;
         }
         TrainProtectionPlugin oldPlugin = this.protectionPlugins.get(id);
         if (oldPlugin == plugin) {
+            this.setProtectionPluginState(id, true);
             return true;
         }
         if (oldPlugin != null) {
@@ -1081,6 +1130,7 @@ public abstract class EntityTrainBase extends EntityVehicleBase<TrainConfig> imp
         }
         this.protectionPlugins.put(id, plugin);
         this.onProtectionPluginRegister(id, plugin);
+        this.setProtectionPluginState(id, true);
         return true;
     }
 
@@ -1089,10 +1139,29 @@ public abstract class EntityTrainBase extends EntityVehicleBase<TrainConfig> imp
         if (plugin != null) {
             this.onProtectionPluginUnregister(id, plugin);
         }
+        this.setProtectionPluginState(id, false);
     }
 
     public boolean hasProtectionPlugin(String id) {
         return this.protectionPlugins.containsKey(id);
+    }
+
+    public boolean isProtectionPluginEnabled(String id) {
+        return this.enabledProtectionPluginIds.contains(id);
+    }
+
+    public void applyProtectionPluginState(String id, boolean enabled) {
+        this.setProtectionPluginState(id, enabled);
+    }
+
+    private void setProtectionPluginState(String id, boolean enabled) {
+        if (id != null && !id.isEmpty()) {
+            if (enabled) {
+                this.enabledProtectionPluginIds.add(id);
+            } else {
+                this.enabledProtectionPluginIds.remove(id);
+            }
+        }
     }
 
     public void onProtectionPluginATSKeyDown(EntityPlayer player) {

--- a/src/main/java/jp/ngt/rtm/entity/train/EntityTrainBase.java
+++ b/src/main/java/jp/ngt/rtm/entity/train/EntityTrainBase.java
@@ -1157,6 +1157,10 @@ public abstract class EntityTrainBase extends EntityVehicleBase<TrainConfig> imp
         return this.enabledProtectionPluginIds.contains(id);
     }
 
+    public DataMap.NamespaceView getProtectionPluginData(String id) {
+        return this.getResourceState().getDataMap().namespace(id);
+    }
+
     public void applyProtectionPluginState(String id, boolean enabled) {
         this.setProtectionPluginState(id, enabled);
     }

--- a/src/main/java/jp/ngt/rtm/entity/train/EntityTrainBase.java
+++ b/src/main/java/jp/ngt/rtm/entity/train/EntityTrainBase.java
@@ -1014,8 +1014,7 @@ public abstract class EntityTrainBase extends EntityVehicleBase<TrainConfig> imp
     private byte clampTrainStateData(int id, byte data) {
         TrainStateType trainStateType = TrainState.getStateType(id);
         if (trainStateType == TrainStateType.State_Notch) {
-            TrainConfig cfg = this.getModelSet().getConfig();
-            return NGTMath.clamp(data, (byte) -(cfg.deccelerations.length - 1), (byte) cfg.maxSpeed.length);
+            return NGTMath.clamp(data, (byte) this.getEBNotch(), (byte) this.getMaxNotch());
         } else {
             return NGTMath.clamp(data, trainStateType.min, trainStateType.max);
         }
@@ -1086,6 +1085,14 @@ public abstract class EntityTrainBase extends EntityVehicleBase<TrainConfig> imp
         return this.getByteFromDataWatcher(TrainStateType.State_Notch.id);
     }
 
+    public int getMaxNotch() {
+        return this.getModelSet().getConfig().maxSpeed.length;
+    }
+
+    public int getEBNotch() {
+        return -(this.getModelSet().getConfig().deccelerations.length - 1);
+    }
+
     public int getInternalNotch() {
         return this.getByteFromDataWatcher(TrainStateType.State_InternalNotch.id);
     }
@@ -1095,7 +1102,7 @@ public abstract class EntityTrainBase extends EntityVehicleBase<TrainConfig> imp
     }
 
     private void applyInternalNotch(int notch) {
-        int data = Math.max(Byte.MIN_VALUE, Math.min(Byte.MAX_VALUE, notch));
+        int data = Math.max(this.getEBNotch(), Math.min(this.getMaxNotch(), notch));
         if (this.getByteFromDataWatcher(TrainStateType.State_InternalNotch.id) != data) {
             this.setByteToDataWatcher(TrainStateType.State_InternalNotch.id, (byte) data);
         }
@@ -1235,7 +1242,7 @@ public abstract class EntityTrainBase extends EntityVehicleBase<TrainConfig> imp
 
     public void setEBNotch() {
         int prevNotch = this.getNotch();
-        int EB_NOTCH = -(this.getModelSet().getConfig().deccelerations.length - 1);
+        int EB_NOTCH = this.getEBNotch();
         if (prevNotch != EB_NOTCH) {
             this.setByteToDataWatcher(TrainStateType.State_Notch.id, (byte) EB_NOTCH);
         }

--- a/src/main/java/jp/ngt/rtm/entity/train/EntityTrainBase.java
+++ b/src/main/java/jp/ngt/rtm/entity/train/EntityTrainBase.java
@@ -1101,11 +1101,6 @@ public abstract class EntityTrainBase extends EntityVehicleBase<TrainConfig> imp
         }
     }
 
-    public boolean enableProtectionPlugin(String id) {
-        TrainProtectionPlugin plugin = TrainProtectionPluginManager.getPlugin(id);
-        return this.attachProtectionPlugin(id, plugin);
-    }
-
     public void setProtectionPluginEnabled(String id, boolean enabled) {
         if (enabled) {
             this.enableProtectionPlugin(id);
@@ -1117,14 +1112,14 @@ public abstract class EntityTrainBase extends EntityVehicleBase<TrainConfig> imp
         }
     }
 
-    private boolean attachProtectionPlugin(String id, TrainProtectionPlugin plugin) {
+    private void attachProtectionPlugin(String id, TrainProtectionPlugin plugin) {
         if (id == null || id.isEmpty() || plugin == null) {
-            return false;
+            return;
         }
         TrainProtectionPlugin oldPlugin = this.protectionPlugins.get(id);
         if (oldPlugin == plugin) {
             this.setProtectionPluginState(id, true);
-            return true;
+            return;
         }
         if (oldPlugin != null) {
             this.onProtectionPluginUnregister(id, oldPlugin);
@@ -1132,10 +1127,14 @@ public abstract class EntityTrainBase extends EntityVehicleBase<TrainConfig> imp
         this.protectionPlugins.put(id, plugin);
         this.onProtectionPluginRegister(id, plugin);
         this.setProtectionPluginState(id, true);
-        return true;
     }
 
-    public void disableProtectionPlugin(String id) {
+    private void enableProtectionPlugin(String id) {
+        TrainProtectionPlugin plugin = TrainProtectionPluginManager.getPlugin(id);
+        this.attachProtectionPlugin(id, plugin);
+    }
+
+    private void disableProtectionPlugin(String id) {
         TrainProtectionPlugin plugin = this.protectionPlugins.remove(id);
         if (plugin != null) {
             this.onProtectionPluginUnregister(id, plugin);

--- a/src/main/java/jp/ngt/rtm/entity/train/EntityTrainBase.java
+++ b/src/main/java/jp/ngt/rtm/entity/train/EntityTrainBase.java
@@ -15,12 +15,16 @@ import jp.ngt.rtm.electric.WireManager;
 import jp.ngt.rtm.entity.npc.EntityMotorman;
 import jp.ngt.rtm.entity.npc.macro.MacroRecorder;
 import jp.ngt.rtm.entity.train.parts.EntityVehiclePart;
+import jp.ngt.rtm.entity.train.protection.ScriptTrainProtectionPlugin;
+import jp.ngt.rtm.entity.train.protection.TrainProtectionContext;
+import jp.ngt.rtm.entity.train.protection.TrainProtectionPlugin;
 import jp.ngt.rtm.entity.train.util.*;
 import jp.ngt.rtm.entity.train.util.TrainState.TrainStateType;
 import jp.ngt.rtm.entity.vehicle.EntityVehicleBase;
 import jp.ngt.rtm.item.ItemTrain;
 import jp.ngt.rtm.modelpack.cfg.TrainConfig;
 import jp.ngt.rtm.modelpack.modelset.ModelSetVehicleBase;
+import jp.ngt.rtm.modelpack.state.DataMap;
 import jp.ngt.rtm.network.PacketNotice;
 import jp.ngt.rtm.network.PacketSetTrainState;
 import jp.ngt.rtm.rail.TileEntityLargeRailBase;
@@ -65,6 +69,7 @@ public abstract class EntityTrainBase extends EntityVehicleBase<TrainConfig> imp
      */
     public int brakeCount = 72;
     public int atsCount;
+    private final Map<String, TrainProtectionPlugin> protectionPlugins = new LinkedHashMap<>();
     @SideOnly(Side.CLIENT)
     public int brakeAirCount;
     @SideOnly(Side.CLIENT)
@@ -494,6 +499,8 @@ public abstract class EntityTrainBase extends EntityVehicleBase<TrainConfig> imp
 
     protected void updateSpeed() {
         int notch = this.getNotch();
+        ModelSetVehicleBase<TrainConfig> set = this.getModelSet();
+        TrainConfig cfg = set.getConfig();
 
 //		if (this.riddenByEntity == null || !(this.riddenByEntity instanceof EntityPlayer || this.riddenByEntity instanceof EntityMotorman)) {
 //			if (notch > 0) {
@@ -503,10 +510,15 @@ public abstract class EntityTrainBase extends EntityVehicleBase<TrainConfig> imp
 
         boolean isBrakeDisabled = true;
         float speed = this.trainSpeed;
+        if (!this.worldObj.isRemote) {
+            this.updateInternalNotch(notch, speed);
+        }
+        int controlNotch = this.getControlNotch(notch, this.getInternalNotch(), cfg);
+        int brakeNotch = controlNotch < 0 ? controlNotch : notch;
 
         //ブレーキ処理, 全ての車両で
-        if (notch < 0) {
-            int max = notch * -18;
+        if (brakeNotch < 0) {
+            int max = brakeNotch * -18;
             if (this.brakeCount < max) {
                 ++this.brakeCount;
                 if (this.worldObj.isRemote) {
@@ -529,8 +541,7 @@ public abstract class EntityTrainBase extends EntityVehicleBase<TrainConfig> imp
         //速度処理, 先頭車のみ
         if (this.isControlCar()) {
             if (isBrakeDisabled && !this.worldObj.isRemote) {
-                ModelSetVehicleBase<TrainConfig> set = this.getModelSet();
-                float acceleration = TrainSpeedManager.getAcceleration(this, notch, Math.abs(speed), set.getConfig());
+                float acceleration = TrainSpeedManager.getAcceleration(this, controlNotch, Math.abs(speed), cfg);
                 TrainState dir = this.getTrainState(10);
                 if ((dir == TrainState.Direction_Back && speed > 0) || (dir == TrainState.Direction_Front && speed < 0)) {
                     acceleration = Math.abs(acceleration);
@@ -541,12 +552,12 @@ public abstract class EntityTrainBase extends EntityVehicleBase<TrainConfig> imp
 
                 speed += acceleration;
 
-                if (notch >= 0)//ブレーキ解
+                if (controlNotch >= 0)//ブレーキ解
                 {
                     float deceleration;
                     if (this.rotationPitch == 0.0F) {
 //						float f1 = 0.0002F;
-                        float f1 = -set.getConfig().deccelerations[0];
+                        float f1 = -cfg.deccelerations[0];
                         deceleration = speed > 0.0F ? f1 : (speed < 0.0F ? -f1 : 0.0F);
                     } else//坂
                     {
@@ -561,6 +572,38 @@ public abstract class EntityTrainBase extends EntityVehicleBase<TrainConfig> imp
                 this.setSpeed(speed);
             }
         }
+    }
+
+    private void updateInternalNotch(int physicalNotch, float speed) {
+        int internalNotch = 0;
+        if (!this.protectionPlugins.isEmpty()) {
+            for (Map.Entry<String, TrainProtectionPlugin> entry : new ArrayList<>(this.protectionPlugins.entrySet())) {
+                try {
+                    TrainProtectionContext context = new TrainProtectionContext(this, entry.getKey(), physicalNotch, speed);
+                    internalNotch = this.selectInternalNotch(internalNotch, entry.getValue().onServerTick(context));
+                } catch (Exception e) {
+                    NGTLog.debug("[RTM] Failed to update train protection plugin: " + entry.getKey());
+                    e.printStackTrace();
+                }
+            }
+        }
+        this.applyInternalNotch(internalNotch);
+    }
+
+    private int getControlNotch(int physicalNotch, int internalNotch, TrainConfig cfg) {
+        if (internalNotch == 0) {
+            return physicalNotch;
+        }
+
+        if (internalNotch > 0) {
+            return physicalNotch == 0 ? internalNotch : physicalNotch;
+        }
+
+        if (physicalNotch < 0) {
+            return Math.min(physicalNotch, internalNotch);
+        }
+
+        return TrainSpeedManager.clampBrakeNotch(internalNotch, cfg);
     }
 
     protected void moveTrain() {
@@ -1014,6 +1057,94 @@ public abstract class EntityTrainBase extends EntityVehicleBase<TrainConfig> imp
         return this.getByteFromDataWatcher(TrainStateType.State_Notch.id);
     }
 
+    public int getInternalNotch() {
+        return this.getByteFromDataWatcher(TrainStateType.State_InternalNotch.id);
+    }
+
+    private int selectInternalNotch(int current, int candidate) {
+        return candidate != 0 && (current == 0 || candidate < current) ? candidate : current;
+    }
+
+    private void applyInternalNotch(int notch) {
+        int data = Math.max(Byte.MIN_VALUE, Math.min(Byte.MAX_VALUE, notch));
+        if (this.getByteFromDataWatcher(TrainStateType.State_InternalNotch.id) != data) {
+            this.setByteToDataWatcher(TrainStateType.State_InternalNotch.id, (byte) data);
+        }
+    }
+
+    public void registerProtectionPlugin(String id, TrainProtectionPlugin plugin) {
+        if (id == null || id.isEmpty() || plugin == null) {
+            return;
+        }
+        TrainProtectionPlugin oldPlugin = this.protectionPlugins.get(id);
+        if (oldPlugin == plugin) {
+            return;
+        }
+        if (oldPlugin != null) {
+            this.onProtectionPluginUnregister(id, oldPlugin);
+        }
+        this.protectionPlugins.put(id, plugin);
+        this.onProtectionPluginRegister(id, plugin);
+    }
+
+    public void registerProtectionPlugin(String id, Object jsPlugin) {
+        if (jsPlugin instanceof TrainProtectionPlugin) {
+            this.registerProtectionPlugin(id, (TrainProtectionPlugin) jsPlugin);
+        } else {
+            this.registerProtectionPlugin(id, new ScriptTrainProtectionPlugin(jsPlugin));
+        }
+    }
+
+    public boolean unregisterProtectionPlugin(String id) {
+        TrainProtectionPlugin plugin = this.protectionPlugins.remove(id);
+        if (plugin != null) {
+            this.onProtectionPluginUnregister(id, plugin);
+            return true;
+        }
+        return false;
+    }
+
+    public boolean hasProtectionPlugin(String id) {
+        return this.protectionPlugins.containsKey(id);
+    }
+
+    public boolean onProtectionPluginATSKeyDown(EntityPlayer player) {
+        if (this.protectionPlugins.isEmpty()) {
+            return false;
+        }
+
+        boolean handled = false;
+        for (Map.Entry<String, TrainProtectionPlugin> entry : new ArrayList<>(this.protectionPlugins.entrySet())) {
+            try {
+                TrainProtectionContext context = new TrainProtectionContext(this, entry.getKey(), this.getNotch(), this.getSpeed());
+                handled |= entry.getValue().onATSKeyDown(context, player);
+            } catch (Exception e) {
+                NGTLog.debug("[RTM] Failed to notify train protection plugin ATS key down: " + entry.getKey());
+                e.printStackTrace();
+            }
+        }
+        return handled;
+    }
+
+    private void onProtectionPluginUnregister(String id, TrainProtectionPlugin plugin) {
+        try {
+            this.getResourceState().getDataMap().namespace(id).clear(DataMap.SYNC_FLAG);
+            plugin.onUnregister(this);
+        } catch (Exception e) {
+            NGTLog.debug("[RTM] Failed to unregister train protection plugin: " + id);
+            e.printStackTrace();
+        }
+    }
+
+    private void onProtectionPluginRegister(String id, TrainProtectionPlugin plugin) {
+        try {
+            plugin.onRegister(this);
+        } catch (Exception e) {
+            NGTLog.debug("[RTM] Failed to register train protection plugin: " + id);
+            e.printStackTrace();
+        }
+    }
+
     /**
      * プレーヤーが変更したとき呼ぶ
      */
@@ -1086,7 +1217,7 @@ public abstract class EntityTrainBase extends EntityVehicleBase<TrainConfig> imp
      * 0:direction<br>
      * 1:notch<br>
      * 2:signal<br>
-     * 3:<br>
+     * 3:internal_notch<br>
      * 4:door<br>
      * 5:light<br>
      * 6:pantograph<br>

--- a/src/main/java/jp/ngt/rtm/entity/train/EntityTrainBase.java
+++ b/src/main/java/jp/ngt/rtm/entity/train/EntityTrainBase.java
@@ -608,7 +608,8 @@ public abstract class EntityTrainBase extends EntityVehicleBase<TrainConfig> imp
             for (Map.Entry<String, TrainProtectionPlugin> entry : new ArrayList<>(this.protectionPlugins.entrySet())) {
                 try {
                     TrainProtectionContext context = new TrainProtectionContext(this, entry.getKey(), physicalNotch, speed);
-                    internalNotch = this.selectInternalNotch(internalNotch, entry.getValue().onServerTick(context));
+                    entry.getValue().onServerTick(context);
+                    internalNotch = this.selectInternalNotch(internalNotch, context.getRequestedInternalNotch());
                 } catch (Exception e) {
                     NGTLog.debug("[RTM] Failed to update train protection plugin: " + entry.getKey());
                     e.printStackTrace();

--- a/src/main/java/jp/ngt/rtm/entity/train/EntityTrainBase.java
+++ b/src/main/java/jp/ngt/rtm/entity/train/EntityTrainBase.java
@@ -1113,7 +1113,7 @@ public abstract class EntityTrainBase extends EntityVehicleBase<TrainConfig> imp
     }
 
     private void attachProtectionPlugin(String id, TrainProtectionPlugin plugin) {
-        if (id == null || id.isEmpty() || plugin == null) {
+        if (id == null || id.isEmpty() || id.contains(":") || plugin == null) {
             return;
         }
         TrainProtectionPlugin oldPlugin = this.protectionPlugins.get(id);

--- a/src/main/java/jp/ngt/rtm/entity/train/protection/RawScriptTrainProtectionPlugin.kt
+++ b/src/main/java/jp/ngt/rtm/entity/train/protection/RawScriptTrainProtectionPlugin.kt
@@ -1,0 +1,73 @@
+package jp.ngt.rtm.entity.train.protection
+
+import jdk.nashorn.api.scripting.ScriptObjectMirror
+import jp.ngt.rtm.entity.train.EntityTrainBase
+import net.minecraft.entity.player.EntityPlayer
+import java.lang.reflect.InvocationTargetException
+
+class RawScriptTrainProtectionPlugin(private val scriptPlugin: Any?) : ScriptTrainProtectionPlugin() {
+    override fun onServerTick(context: TrainProtectionContext): Int {
+        val plugin = scriptPlugin ?: return 0
+
+        if (plugin is ScriptObjectMirror) {
+            return if (plugin.hasMember("onServerTick")) {
+                toInt(plugin.callMember("onServerTick", context))
+            } else {
+                0
+            }
+        }
+
+        return callJavaMethod("onServerTick", arrayOf(TrainProtectionContext::class.java), arrayOf(context))
+    }
+
+    override fun onRegister(train: EntityTrainBase) {
+        callVoidMethod("onRegister", arrayOf(EntityTrainBase::class.java), arrayOf(train))
+    }
+
+    override fun onUnregister(train: EntityTrainBase) {
+        callVoidMethod("onUnregister", arrayOf(EntityTrainBase::class.java), arrayOf(train))
+    }
+
+    override fun onATSKeyDown(context: TrainProtectionContext, player: EntityPlayer) {
+        val plugin = scriptPlugin ?: return
+
+        if (plugin is ScriptObjectMirror) {
+            if (plugin.hasMember("onATSKeyDown")) {
+                toBoolean(plugin.callMember("onATSKeyDown", context, player))
+            }
+            return
+        }
+
+        callVoidMethod(
+            "onATSKeyDown",
+            arrayOf(TrainProtectionContext::class.java, EntityPlayer::class.java),
+            arrayOf(context, player)
+        )
+    }
+
+    private fun callJavaMethod(name: String, parameterTypes: Array<Class<*>>, args: Array<Any>): Int {
+        return try {
+            val method = scriptPlugin!!.javaClass.getMethod(name, *parameterTypes)
+            toInt(method.invoke(scriptPlugin, *args))
+        } catch (_: NoSuchMethodException) {
+            0
+        } catch (e: IllegalAccessException) {
+            throw RuntimeException(e)
+        } catch (e: InvocationTargetException) {
+            throw RuntimeException(e)
+        }
+    }
+
+    private fun callVoidMethod(name: String, parameterTypes: Array<Class<*>>, args: Array<Any>) {
+        val plugin = scriptPlugin ?: return
+
+        if (plugin is ScriptObjectMirror) {
+            if (plugin.hasMember(name)) {
+                plugin.callMember(name, *args)
+            }
+            return
+        }
+
+        callJavaMethod(name, parameterTypes, args)
+    }
+}

--- a/src/main/java/jp/ngt/rtm/entity/train/protection/RawScriptTrainProtectionPlugin.kt
+++ b/src/main/java/jp/ngt/rtm/entity/train/protection/RawScriptTrainProtectionPlugin.kt
@@ -6,18 +6,17 @@ import net.minecraft.entity.player.EntityPlayer
 import java.lang.reflect.InvocationTargetException
 
 class RawScriptTrainProtectionPlugin(private val scriptPlugin: Any?) : ScriptTrainProtectionPlugin() {
-    override fun onServerTick(context: TrainProtectionContext): Int {
-        val plugin = scriptPlugin ?: return 0
+    override fun onServerTick(context: TrainProtectionContext) {
+        val plugin = scriptPlugin ?: return
 
         if (plugin is ScriptObjectMirror) {
-            return if (plugin.hasMember("onServerTick")) {
-                toInt(plugin.callMember("onServerTick", context))
-            } else {
-                0
+            if (plugin.hasMember("onServerTick")) {
+                plugin.callMember("onServerTick", context)
             }
+            return
         }
 
-        return callJavaMethod("onServerTick", arrayOf(TrainProtectionContext::class.java), arrayOf(context))
+        callVoidMethod("onServerTick", arrayOf(TrainProtectionContext::class.java), arrayOf(context))
     }
 
     override fun onRegister(train: EntityTrainBase) {
@@ -33,7 +32,7 @@ class RawScriptTrainProtectionPlugin(private val scriptPlugin: Any?) : ScriptTra
 
         if (plugin is ScriptObjectMirror) {
             if (plugin.hasMember("onATSKeyDown")) {
-                toBoolean(plugin.callMember("onATSKeyDown", context, player))
+                plugin.callMember("onATSKeyDown", context, player)
             }
             return
         }
@@ -45,12 +44,11 @@ class RawScriptTrainProtectionPlugin(private val scriptPlugin: Any?) : ScriptTra
         )
     }
 
-    private fun callJavaMethod(name: String, parameterTypes: Array<Class<*>>, args: Array<Any>): Int {
-        return try {
+    private fun callJavaMethod(name: String, parameterTypes: Array<Class<*>>, args: Array<Any>) {
+        try {
             val method = scriptPlugin!!.javaClass.getMethod(name, *parameterTypes)
-            toInt(method.invoke(scriptPlugin, *args))
+            method.invoke(scriptPlugin, *args)
         } catch (_: NoSuchMethodException) {
-            0
         } catch (e: IllegalAccessException) {
             throw RuntimeException(e)
         } catch (e: InvocationTargetException) {

--- a/src/main/java/jp/ngt/rtm/entity/train/protection/RawSimpleScriptTrainProtectionPlugin.kt
+++ b/src/main/java/jp/ngt/rtm/entity/train/protection/RawSimpleScriptTrainProtectionPlugin.kt
@@ -3,5 +3,7 @@ package jp.ngt.rtm.entity.train.protection
 import jdk.nashorn.api.scripting.ScriptObjectMirror
 
 class RawSimpleScriptTrainProtectionPlugin(private val function: ScriptObjectMirror) : ScriptTrainProtectionPlugin() {
-    override fun onServerTick(context: TrainProtectionContext) = toInt(function.call(null, context))
+    override fun onServerTick(context: TrainProtectionContext) {
+        function.call(null, context)
+    }
 }

--- a/src/main/java/jp/ngt/rtm/entity/train/protection/RawSimpleScriptTrainProtectionPlugin.kt
+++ b/src/main/java/jp/ngt/rtm/entity/train/protection/RawSimpleScriptTrainProtectionPlugin.kt
@@ -1,0 +1,7 @@
+package jp.ngt.rtm.entity.train.protection
+
+import jdk.nashorn.api.scripting.ScriptObjectMirror
+
+class RawSimpleScriptTrainProtectionPlugin(private val function: ScriptObjectMirror) : ScriptTrainProtectionPlugin() {
+    override fun onServerTick(context: TrainProtectionContext) = toInt(function.call(null, context))
+}

--- a/src/main/java/jp/ngt/rtm/entity/train/protection/RtmDefaultTrainProtectionPlugin.kt
+++ b/src/main/java/jp/ngt/rtm/entity/train/protection/RtmDefaultTrainProtectionPlugin.kt
@@ -14,7 +14,7 @@ object RtmDefaultTrainProtectionPlugin : TrainProtectionPlugin() {
     private const val WARNING_TICKS = 100
     private const val DATA_FLAG = 0
 
-    override fun onServerTick(context: TrainProtectionContext): Int {
+    override fun onServerTick(context: TrainProtectionContext) {
         var count = context.dataMap.getInt(ATS_COUNT)
         if (count <= 0 && context.signal == STOP_SIGNAL && context.speed > 0.0F) {
             count = 1
@@ -23,7 +23,7 @@ object RtmDefaultTrainProtectionPlugin : TrainProtectionPlugin() {
         }
 
         if (count <= 0) {
-            return 0
+            return
         }
 
         if (count >= WARNING_TICKS) {
@@ -32,7 +32,6 @@ object RtmDefaultTrainProtectionPlugin : TrainProtectionPlugin() {
         } else {
             context.dataMap.setInt(ATS_COUNT, count, DATA_FLAG)
         }
-        return 0
     }
 
     override fun onATSKeyDown(context: TrainProtectionContext, player: EntityPlayer) {

--- a/src/main/java/jp/ngt/rtm/entity/train/protection/RtmDefaultTrainProtectionPlugin.kt
+++ b/src/main/java/jp/ngt/rtm/entity/train/protection/RtmDefaultTrainProtectionPlugin.kt
@@ -50,5 +50,8 @@ object RtmDefaultTrainProtectionPlugin : TrainProtectionPlugin() {
 
     override fun onUnregister(train: EntityTrainBase) {
         train.resourceState.dataMap.namespace(ID).remove(ATS_COUNT, DATA_FLAG)
+        if (train.signal == ACKNOWLEDGED_SIGNAL) {
+            train.setSignal2(0)
+        }
     }
 }

--- a/src/main/java/jp/ngt/rtm/entity/train/protection/RtmDefaultTrainProtectionPlugin.kt
+++ b/src/main/java/jp/ngt/rtm/entity/train/protection/RtmDefaultTrainProtectionPlugin.kt
@@ -1,0 +1,54 @@
+package jp.ngt.rtm.entity.train.protection
+
+import jp.ngt.rtm.entity.train.EntityTrainBase
+import net.minecraft.entity.player.EntityPlayer
+
+object RtmDefaultTrainProtectionPlugin : TrainProtectionPlugin() {
+    const val ID: String = "rtm_default"
+    const val DISPLAY_NAME: String = "RTM Default"
+
+    private const val ATS_COUNT = "atsCount"
+    private const val STOP_SIGNAL = 1
+    private const val ACKNOWLEDGED_SIGNAL = -1
+    private const val RESET_ACK_NOTCH = -8
+    private const val WARNING_TICKS = 100
+    private const val DATA_FLAG = 0
+
+    override fun onServerTick(context: TrainProtectionContext): Int {
+        var count = context.dataMap.getInt(ATS_COUNT)
+        if (count <= 0 && context.signal == STOP_SIGNAL && context.speed > 0.0F) {
+            count = 1
+        } else if (count > 0) {
+            count += 1
+        }
+
+        if (count <= 0) {
+            return 0
+        }
+
+        if (count >= WARNING_TICKS) {
+            context.train.stopTrain(false)
+            context.dataMap.remove(ATS_COUNT, DATA_FLAG)
+        } else {
+            context.dataMap.setInt(ATS_COUNT, count, DATA_FLAG)
+        }
+        return 0
+    }
+
+    override fun onATSKeyDown(context: TrainProtectionContext, player: EntityPlayer) {
+        when (context.signal) {
+            STOP_SIGNAL -> {
+                context.train.setSignal2(ACKNOWLEDGED_SIGNAL)
+                context.dataMap.remove(ATS_COUNT, DATA_FLAG)
+            }
+
+            ACKNOWLEDGED_SIGNAL if context.notch == RESET_ACK_NOTCH -> {
+                context.train.setSignal2(0)
+            }
+        }
+    }
+
+    override fun onUnregister(train: EntityTrainBase) {
+        train.resourceState.dataMap.namespace(ID).remove(ATS_COUNT, DATA_FLAG)
+    }
+}

--- a/src/main/java/jp/ngt/rtm/entity/train/protection/ScriptEngineTrainProtectionPlugin.kt
+++ b/src/main/java/jp/ngt/rtm/entity/train/protection/ScriptEngineTrainProtectionPlugin.kt
@@ -7,8 +7,8 @@ import javax.script.ScriptEngine
 import javax.script.ScriptException
 
 class ScriptEngineTrainProtectionPlugin(private val engine: ScriptEngine) : ScriptTrainProtectionPlugin() {
-    override fun onServerTick(context: TrainProtectionContext): Int {
-        return callIntFunction("onServerTick", context)
+    override fun onServerTick(context: TrainProtectionContext) {
+        callVoidFunction("onServerTick", context)
     }
 
     override fun onRegister(train: EntityTrainBase) {
@@ -21,16 +21,6 @@ class ScriptEngineTrainProtectionPlugin(private val engine: ScriptEngine) : Scri
 
     override fun onATSKeyDown(context: TrainProtectionContext, player: EntityPlayer) {
         callVoidFunction("onATSKeyDown", context, player)
-    }
-
-    private fun callIntFunction(name: String, vararg args: Any): Int {
-        return try {
-            toInt((engine as Invocable).invokeFunction(name, *args))
-        } catch (_: NoSuchMethodException) {
-            0
-        } catch (e: ScriptException) {
-            throw RuntimeException(e)
-        }
     }
 
     private fun callVoidFunction(name: String, vararg args: Any) {

--- a/src/main/java/jp/ngt/rtm/entity/train/protection/ScriptEngineTrainProtectionPlugin.kt
+++ b/src/main/java/jp/ngt/rtm/entity/train/protection/ScriptEngineTrainProtectionPlugin.kt
@@ -1,0 +1,44 @@
+package jp.ngt.rtm.entity.train.protection
+
+import jp.ngt.rtm.entity.train.EntityTrainBase
+import net.minecraft.entity.player.EntityPlayer
+import javax.script.Invocable
+import javax.script.ScriptEngine
+import javax.script.ScriptException
+
+class ScriptEngineTrainProtectionPlugin(private val engine: ScriptEngine) : ScriptTrainProtectionPlugin() {
+    override fun onServerTick(context: TrainProtectionContext): Int {
+        return callIntFunction("onServerTick", context)
+    }
+
+    override fun onRegister(train: EntityTrainBase) {
+        callVoidFunction("onRegister", train)
+    }
+
+    override fun onUnregister(train: EntityTrainBase) {
+        callVoidFunction("onUnregister", train)
+    }
+
+    override fun onATSKeyDown(context: TrainProtectionContext, player: EntityPlayer) {
+        callVoidFunction("onATSKeyDown", context, player)
+    }
+
+    private fun callIntFunction(name: String, vararg args: Any): Int {
+        return try {
+            toInt((engine as Invocable).invokeFunction(name, *args))
+        } catch (_: NoSuchMethodException) {
+            0
+        } catch (e: ScriptException) {
+            throw RuntimeException(e)
+        }
+    }
+
+    private fun callVoidFunction(name: String, vararg args: Any) {
+        try {
+            (engine as Invocable).invokeFunction(name, *args)
+        } catch (_: NoSuchMethodException) {
+        } catch (e: ScriptException) {
+            throw RuntimeException(e)
+        }
+    }
+}

--- a/src/main/java/jp/ngt/rtm/entity/train/protection/ScriptTrainProtectionPlugin.kt
+++ b/src/main/java/jp/ngt/rtm/entity/train/protection/ScriptTrainProtectionPlugin.kt
@@ -22,32 +22,4 @@ abstract class ScriptTrainProtectionPlugin : TrainProtectionPlugin() {
             throw IllegalArgumentException("Unsupported script plugin type: ${scriptPlugin?.javaClass}")
         }
     }
-
-    protected fun toInt(value: Any?): Int {
-        if (value == null || ScriptObjectMirror.isUndefined(value)) {
-            return 0
-        }
-
-        if (value is Number) {
-            return value.toInt()
-        }
-
-        return value.toString().toIntOrNull() ?: 0
-    }
-
-    protected fun toBoolean(value: Any?): Boolean {
-        if (value == null || ScriptObjectMirror.isUndefined(value)) {
-            return false
-        }
-
-        if (value is Boolean) {
-            return value
-        }
-
-        if (value is Number) {
-            return value.toInt() != 0
-        }
-
-        return value.toString().toBoolean()
-    }
 }

--- a/src/main/java/jp/ngt/rtm/entity/train/protection/ScriptTrainProtectionPlugin.kt
+++ b/src/main/java/jp/ngt/rtm/entity/train/protection/ScriptTrainProtectionPlugin.kt
@@ -1,91 +1,29 @@
 package jp.ngt.rtm.entity.train.protection
 
 import jdk.nashorn.api.scripting.ScriptObjectMirror
-import jp.ngt.rtm.entity.train.EntityTrainBase
-import net.minecraft.entity.player.EntityPlayer
-import java.lang.reflect.InvocationTargetException
+import javax.script.ScriptEngine
 
-class ScriptTrainProtectionPlugin(private val scriptPlugin: Any?) : TrainProtectionPlugin() {
-    override fun onServerTick(context: TrainProtectionContext): Int {
-        val plugin = scriptPlugin ?: return 0
-
-        if (plugin is ScriptObjectMirror) {
-            return when {
-                plugin.isFunction -> toInt(plugin.call(null, context))
-                plugin.hasMember("onServerTick") -> toInt(plugin.callMember("onServerTick", context))
-                else -> 0
+abstract class ScriptTrainProtectionPlugin : TrainProtectionPlugin() {
+    companion object {
+        @JvmStatic
+        fun create(scriptPlugin: Any?): TrainProtectionPlugin {
+            if (scriptPlugin is ScriptEngine) {
+                return ScriptEngineTrainProtectionPlugin(scriptPlugin)
             }
-        }
 
-        return callJavaMethod("onServerTick", arrayOf(TrainProtectionContext::class.java), arrayOf(context))
-    }
-
-    override fun onRegister(train: EntityTrainBase) {
-        callVoidMethod("onRegister", arrayOf(EntityTrainBase::class.java), arrayOf(train))
-    }
-
-    override fun onUnregister(train: EntityTrainBase) {
-        callVoidMethod("onUnregister", arrayOf(EntityTrainBase::class.java), arrayOf(train))
-    }
-
-    override fun onATSKeyDown(context: TrainProtectionContext, player: EntityPlayer): Boolean {
-        val plugin = scriptPlugin ?: return false
-
-        if (plugin is ScriptObjectMirror) {
-            return if (plugin.hasMember("onATSKeyDown")) {
-                toBoolean(plugin.callMember("onATSKeyDown", context, player))
-            } else {
-                false
+            if (scriptPlugin is ScriptObjectMirror) {
+                if (scriptPlugin.isFunction) {
+                    return RawSimpleScriptTrainProtectionPlugin(scriptPlugin)
+                } else {
+                    return RawScriptTrainProtectionPlugin(scriptPlugin)
+                }
             }
-        }
 
-        return callBooleanMethod(
-            "onATSKeyDown",
-            arrayOf(TrainProtectionContext::class.java, EntityPlayer::class.java),
-            arrayOf(context, player)
-        )
-    }
-
-    private fun callJavaMethod(name: String, parameterTypes: Array<Class<*>>, args: Array<Any>): Int {
-        return try {
-            val method = scriptPlugin!!.javaClass.getMethod(name, *parameterTypes)
-            toInt(method.invoke(scriptPlugin, *args))
-        } catch (_: NoSuchMethodException) {
-            0
-        } catch (e: IllegalAccessException) {
-            throw RuntimeException(e)
-        } catch (e: InvocationTargetException) {
-            throw RuntimeException(e)
+            throw IllegalArgumentException("Unsupported script plugin type: ${scriptPlugin?.javaClass}")
         }
     }
 
-    private fun callVoidMethod(name: String, parameterTypes: Array<Class<*>>, args: Array<Any>) {
-        val plugin = scriptPlugin ?: return
-
-        if (plugin is ScriptObjectMirror) {
-            if (plugin.hasMember(name)) {
-                plugin.callMember(name, *args)
-            }
-            return
-        }
-
-        callJavaMethod(name, parameterTypes, args)
-    }
-
-    private fun callBooleanMethod(name: String, parameterTypes: Array<Class<*>>, args: Array<Any>): Boolean {
-        return try {
-            val method = scriptPlugin!!.javaClass.getMethod(name, *parameterTypes)
-            toBoolean(method.invoke(scriptPlugin, *args))
-        } catch (_: NoSuchMethodException) {
-            false
-        } catch (e: IllegalAccessException) {
-            throw RuntimeException(e)
-        } catch (e: InvocationTargetException) {
-            throw RuntimeException(e)
-        }
-    }
-
-    private fun toInt(value: Any?): Int {
+    protected fun toInt(value: Any?): Int {
         if (value == null || ScriptObjectMirror.isUndefined(value)) {
             return 0
         }
@@ -97,7 +35,7 @@ class ScriptTrainProtectionPlugin(private val scriptPlugin: Any?) : TrainProtect
         return value.toString().toIntOrNull() ?: 0
     }
 
-    private fun toBoolean(value: Any?): Boolean {
+    protected fun toBoolean(value: Any?): Boolean {
         if (value == null || ScriptObjectMirror.isUndefined(value)) {
             return false
         }

--- a/src/main/java/jp/ngt/rtm/entity/train/protection/ScriptTrainProtectionPlugin.kt
+++ b/src/main/java/jp/ngt/rtm/entity/train/protection/ScriptTrainProtectionPlugin.kt
@@ -1,0 +1,115 @@
+package jp.ngt.rtm.entity.train.protection
+
+import jdk.nashorn.api.scripting.ScriptObjectMirror
+import jp.ngt.rtm.entity.train.EntityTrainBase
+import net.minecraft.entity.player.EntityPlayer
+import java.lang.reflect.InvocationTargetException
+
+class ScriptTrainProtectionPlugin(private val scriptPlugin: Any?) : TrainProtectionPlugin() {
+    override fun onServerTick(context: TrainProtectionContext): Int {
+        val plugin = scriptPlugin ?: return 0
+
+        if (plugin is ScriptObjectMirror) {
+            return when {
+                plugin.isFunction -> toInt(plugin.call(null, context))
+                plugin.hasMember("onServerTick") -> toInt(plugin.callMember("onServerTick", context))
+                else -> 0
+            }
+        }
+
+        return callJavaMethod("onServerTick", arrayOf(TrainProtectionContext::class.java), arrayOf(context))
+    }
+
+    override fun onRegister(train: EntityTrainBase) {
+        callVoidMethod("onRegister", arrayOf(EntityTrainBase::class.java), arrayOf(train))
+    }
+
+    override fun onUnregister(train: EntityTrainBase) {
+        callVoidMethod("onUnregister", arrayOf(EntityTrainBase::class.java), arrayOf(train))
+    }
+
+    override fun onATSKeyDown(context: TrainProtectionContext, player: EntityPlayer): Boolean {
+        val plugin = scriptPlugin ?: return false
+
+        if (plugin is ScriptObjectMirror) {
+            return if (plugin.hasMember("onATSKeyDown")) {
+                toBoolean(plugin.callMember("onATSKeyDown", context, player))
+            } else {
+                false
+            }
+        }
+
+        return callBooleanMethod(
+            "onATSKeyDown",
+            arrayOf(TrainProtectionContext::class.java, EntityPlayer::class.java),
+            arrayOf(context, player)
+        )
+    }
+
+    private fun callJavaMethod(name: String, parameterTypes: Array<Class<*>>, args: Array<Any>): Int {
+        return try {
+            val method = scriptPlugin!!.javaClass.getMethod(name, *parameterTypes)
+            toInt(method.invoke(scriptPlugin, *args))
+        } catch (_: NoSuchMethodException) {
+            0
+        } catch (e: IllegalAccessException) {
+            throw RuntimeException(e)
+        } catch (e: InvocationTargetException) {
+            throw RuntimeException(e)
+        }
+    }
+
+    private fun callVoidMethod(name: String, parameterTypes: Array<Class<*>>, args: Array<Any>) {
+        val plugin = scriptPlugin ?: return
+
+        if (plugin is ScriptObjectMirror) {
+            if (plugin.hasMember(name)) {
+                plugin.callMember(name, *args)
+            }
+            return
+        }
+
+        callJavaMethod(name, parameterTypes, args)
+    }
+
+    private fun callBooleanMethod(name: String, parameterTypes: Array<Class<*>>, args: Array<Any>): Boolean {
+        return try {
+            val method = scriptPlugin!!.javaClass.getMethod(name, *parameterTypes)
+            toBoolean(method.invoke(scriptPlugin, *args))
+        } catch (_: NoSuchMethodException) {
+            false
+        } catch (e: IllegalAccessException) {
+            throw RuntimeException(e)
+        } catch (e: InvocationTargetException) {
+            throw RuntimeException(e)
+        }
+    }
+
+    private fun toInt(value: Any?): Int {
+        if (value == null || ScriptObjectMirror.isUndefined(value)) {
+            return 0
+        }
+
+        if (value is Number) {
+            return value.toInt()
+        }
+
+        return value.toString().toIntOrNull() ?: 0
+    }
+
+    private fun toBoolean(value: Any?): Boolean {
+        if (value == null || ScriptObjectMirror.isUndefined(value)) {
+            return false
+        }
+
+        if (value is Boolean) {
+            return value
+        }
+
+        if (value is Number) {
+            return value.toInt() != 0
+        }
+
+        return value.toString().toBoolean()
+    }
+}

--- a/src/main/java/jp/ngt/rtm/entity/train/protection/TrainProtectionContext.kt
+++ b/src/main/java/jp/ngt/rtm/entity/train/protection/TrainProtectionContext.kt
@@ -1,0 +1,21 @@
+package jp.ngt.rtm.entity.train.protection
+
+import jp.ngt.rtm.entity.train.EntityTrainBase
+import jp.ngt.rtm.modelpack.state.DataMap
+import net.minecraft.world.World
+
+class TrainProtectionContext(
+    val train: EntityTrainBase,
+    val protectionPluginId: String,
+    val notch: Int,
+    val speed: Float
+) {
+    val world: World
+        get() = train.worldObj
+
+    val signal: Int
+        get() = train.signal
+
+    val dataMap: DataMap.NamespaceView
+        get() = train.resourceState.dataMap.namespace(protectionPluginId)
+}

--- a/src/main/java/jp/ngt/rtm/entity/train/protection/TrainProtectionContext.kt
+++ b/src/main/java/jp/ngt/rtm/entity/train/protection/TrainProtectionContext.kt
@@ -18,4 +18,14 @@ class TrainProtectionContext @JvmOverloads constructor(
 
     val dataMap: DataMap.NamespaceView
         get() = train.resourceState.dataMap.namespace(protectionPluginId)
+
+    /**
+     * 内部ノッチ要求。0は制御要求がないことを意味します。
+     */
+    var requestedInternalNotch: Int = 0
+        private set
+
+    fun requestInternalNotch(notch: Int) {
+        requestedInternalNotch = notch
+    }
 }

--- a/src/main/java/jp/ngt/rtm/entity/train/protection/TrainProtectionContext.kt
+++ b/src/main/java/jp/ngt/rtm/entity/train/protection/TrainProtectionContext.kt
@@ -4,11 +4,11 @@ import jp.ngt.rtm.entity.train.EntityTrainBase
 import jp.ngt.rtm.modelpack.state.DataMap
 import net.minecraft.world.World
 
-class TrainProtectionContext(
+class TrainProtectionContext @JvmOverloads constructor(
     val train: EntityTrainBase,
-    val protectionPluginId: String,
-    val notch: Int,
-    val speed: Float
+    val protectionPluginId: String = "",
+    val notch: Int = train.notch,
+    val speed: Float = train.speed
 ) {
     val world: World
         get() = train.worldObj

--- a/src/main/java/jp/ngt/rtm/entity/train/protection/TrainProtectionPlugin.kt
+++ b/src/main/java/jp/ngt/rtm/entity/train/protection/TrainProtectionPlugin.kt
@@ -18,7 +18,6 @@ abstract class TrainProtectionPlugin {
     /**
      * @return この保安装置がATSキーを処理するか デフォルトのATS処理をスキップする場合はtrue
      */
-    open fun onATSKeyDown(context: TrainProtectionContext, player: EntityPlayer): Boolean {
-        return false
+    open fun onATSKeyDown(context: TrainProtectionContext, player: EntityPlayer) {
     }
 }

--- a/src/main/java/jp/ngt/rtm/entity/train/protection/TrainProtectionPlugin.kt
+++ b/src/main/java/jp/ngt/rtm/entity/train/protection/TrainProtectionPlugin.kt
@@ -5,9 +5,10 @@ import net.minecraft.entity.player.EntityPlayer
 
 abstract class TrainProtectionPlugin {
     /**
-     * @return 内部ノッチ要求 0は制御要求がないことを意味します
+     * ServerTickごとに呼び出されます。
+     * 内部ノッチを要求する場合は context.requestInternalNotch(notch) を呼び出します。
      */
-    abstract fun onServerTick(context: TrainProtectionContext): Int
+    abstract fun onServerTick(context: TrainProtectionContext)
 
     open fun onRegister(train: EntityTrainBase) {
     }

--- a/src/main/java/jp/ngt/rtm/entity/train/protection/TrainProtectionPlugin.kt
+++ b/src/main/java/jp/ngt/rtm/entity/train/protection/TrainProtectionPlugin.kt
@@ -17,7 +17,7 @@ abstract class TrainProtectionPlugin {
     }
 
     /**
-     * @return この保安装置がATSキーを処理するか デフォルトのATS処理をスキップする場合はtrue
+     * ATSキー押下時に呼び出されます
      */
     open fun onATSKeyDown(context: TrainProtectionContext, player: EntityPlayer) {
     }

--- a/src/main/java/jp/ngt/rtm/entity/train/protection/TrainProtectionPlugin.kt
+++ b/src/main/java/jp/ngt/rtm/entity/train/protection/TrainProtectionPlugin.kt
@@ -1,0 +1,24 @@
+package jp.ngt.rtm.entity.train.protection
+
+import jp.ngt.rtm.entity.train.EntityTrainBase
+import net.minecraft.entity.player.EntityPlayer
+
+abstract class TrainProtectionPlugin {
+    /**
+     * @return 内部ノッチ要求 0は制御要求がないことを意味します
+     */
+    abstract fun onServerTick(context: TrainProtectionContext): Int
+
+    open fun onRegister(train: EntityTrainBase) {
+    }
+
+    open fun onUnregister(train: EntityTrainBase) {
+    }
+
+    /**
+     * @return この保安装置がATSキーを処理するか デフォルトのATS処理をスキップする場合はtrue
+     */
+    open fun onATSKeyDown(context: TrainProtectionContext, player: EntityPlayer): Boolean {
+        return false
+    }
+}

--- a/src/main/java/jp/ngt/rtm/entity/train/protection/TrainProtectionPluginConfig.kt
+++ b/src/main/java/jp/ngt/rtm/entity/train/protection/TrainProtectionPluginConfig.kt
@@ -10,7 +10,7 @@ class TrainProtectionPluginConfig @JvmOverloads constructor(
     @JvmField
     var scriptPath: String = "",
     @JvmField
-    var defaultEnabled: Boolean = true
+    var defaultEnabled: Boolean = false
 ) {
     companion object {
         @JvmField

--- a/src/main/java/jp/ngt/rtm/entity/train/protection/TrainProtectionPluginConfig.kt
+++ b/src/main/java/jp/ngt/rtm/entity/train/protection/TrainProtectionPluginConfig.kt
@@ -10,7 +10,9 @@ class TrainProtectionPluginConfig @JvmOverloads constructor(
     @JvmField
     var scriptPath: String = "",
     @JvmField
-    var defaultEnabled: Boolean = false
+    var defaultEnabled: Boolean = false,
+    @JvmField
+    var hidden: Boolean = false
 ) {
     companion object {
         @JvmField

--- a/src/main/java/jp/ngt/rtm/entity/train/protection/TrainProtectionPluginConfig.kt
+++ b/src/main/java/jp/ngt/rtm/entity/train/protection/TrainProtectionPluginConfig.kt
@@ -1,0 +1,29 @@
+package jp.ngt.rtm.entity.train.protection
+
+import java.util.regex.Pattern
+
+class TrainProtectionPluginConfig @JvmOverloads constructor(
+    @JvmField
+    var id: String = "",
+    @JvmField
+    var displayName: String = id,
+    @JvmField
+    var scriptPath: String = "",
+    @JvmField
+    var defaultEnabled: Boolean = true
+) {
+    companion object {
+        @JvmField
+        val CONFIG_FILE_PATTERN: Pattern = Pattern.compile("TrainProtectionPlugin_.*\\.json")
+    }
+
+    fun checkFields() {
+        if (id.isEmpty()) {
+            throw IllegalArgumentException("Train protection plugin id is empty")
+        }
+
+        if (scriptPath.isEmpty()) {
+            throw IllegalArgumentException("Train protection plugin scriptPath is empty")
+        }
+    }
+}

--- a/src/main/java/jp/ngt/rtm/entity/train/protection/TrainProtectionPluginInfo.kt
+++ b/src/main/java/jp/ngt/rtm/entity/train/protection/TrainProtectionPluginInfo.kt
@@ -1,0 +1,10 @@
+package jp.ngt.rtm.entity.train.protection
+
+class TrainProtectionPluginInfo(
+    @JvmField
+    val id: String,
+    @JvmField
+    val displayName: String,
+    @JvmField
+    val defaultEnabled: Boolean
+)

--- a/src/main/java/jp/ngt/rtm/entity/train/protection/TrainProtectionPluginInfo.kt
+++ b/src/main/java/jp/ngt/rtm/entity/train/protection/TrainProtectionPluginInfo.kt
@@ -6,5 +6,7 @@ class TrainProtectionPluginInfo(
     @JvmField
     val displayName: String,
     @JvmField
-    val defaultEnabled: Boolean
+    val defaultEnabled: Boolean,
+    @JvmField
+    val hidden: Boolean
 )

--- a/src/main/java/jp/ngt/rtm/entity/train/protection/TrainProtectionPluginManager.kt
+++ b/src/main/java/jp/ngt/rtm/entity/train/protection/TrainProtectionPluginManager.kt
@@ -30,12 +30,7 @@ object TrainProtectionPluginManager {
     fun register(config: TrainProtectionPluginConfig) {
         config.checkFields()
 
-        entries[config.id] = Entry(
-            id = config.id,
-            displayName = config.displayName,
-            defaultEnabled = config.defaultEnabled,
-            plugin = createPlugin(config),
-        )
+        putProtectionPlugin(config.id, config.displayName, createPlugin(config), config.defaultEnabled)
     }
 
     @JvmStatic
@@ -100,7 +95,8 @@ object TrainProtectionPluginManager {
         plugin: TrainProtectionPlugin,
         defaultEnabled: Boolean,
     ): Boolean {
-        if (id.isEmpty()) {
+        if (id.isEmpty() || id.contains(':')) {
+            NGTLog.debug("[RTM] Invalid train protection plugin ID: `$id`")
             return false
         }
         entries[id] = Entry(

--- a/src/main/java/jp/ngt/rtm/entity/train/protection/TrainProtectionPluginManager.kt
+++ b/src/main/java/jp/ngt/rtm/entity/train/protection/TrainProtectionPluginManager.kt
@@ -60,7 +60,7 @@ object TrainProtectionPluginManager {
         }
 
         try {
-            train.enableProtectionPlugin(id)
+            train.setProtectionPluginEnabled(id, true)
         } catch (e: Exception) {
             NGTLog.debug("[RTM] Failed to enable train protection plugin: $id")
             e.printStackTrace()

--- a/src/main/java/jp/ngt/rtm/entity/train/protection/TrainProtectionPluginManager.kt
+++ b/src/main/java/jp/ngt/rtm/entity/train/protection/TrainProtectionPluginManager.kt
@@ -30,7 +30,13 @@ object TrainProtectionPluginManager {
     fun register(config: TrainProtectionPluginConfig) {
         config.checkFields()
 
-        putProtectionPlugin(config.id, config.displayName, createPlugin(config), config.defaultEnabled)
+        putProtectionPlugin(
+            config.id,
+            config.displayName,
+            createPlugin(config),
+            config.defaultEnabled,
+            config.hidden
+        )
     }
 
     @JvmStatic
@@ -94,6 +100,7 @@ object TrainProtectionPluginManager {
         displayName: String,
         plugin: TrainProtectionPlugin,
         defaultEnabled: Boolean,
+        hidden: Boolean = false,
     ): Boolean {
         if (id.isEmpty() || id.contains(':')) {
             NGTLog.debug("[RTM] Invalid train protection plugin ID: `$id`")
@@ -103,6 +110,7 @@ object TrainProtectionPluginManager {
             id = id,
             displayName = displayName,
             defaultEnabled = defaultEnabled,
+            hidden = hidden,
             plugin = plugin
         )
         return true
@@ -131,7 +139,7 @@ object TrainProtectionPluginManager {
     private fun getLocalPluginInfos(): List<TrainProtectionPluginInfo> {
         return entries.values
             .sortedBy { it.id }
-            .map { TrainProtectionPluginInfo(it.id, it.displayName, it.defaultEnabled) }
+            .map { TrainProtectionPluginInfo(it.id, it.displayName, it.defaultEnabled, it.hidden) }
     }
 
     private fun createPlugin(config: TrainProtectionPluginConfig): TrainProtectionPlugin {
@@ -142,6 +150,7 @@ object TrainProtectionPluginManager {
         val id: String,
         val displayName: String,
         val defaultEnabled: Boolean,
+        val hidden: Boolean,
         val plugin: TrainProtectionPlugin
     )
 }

--- a/src/main/java/jp/ngt/rtm/entity/train/protection/TrainProtectionPluginManager.kt
+++ b/src/main/java/jp/ngt/rtm/entity/train/protection/TrainProtectionPluginManager.kt
@@ -1,0 +1,115 @@
+package jp.ngt.rtm.entity.train.protection
+
+import jp.ngt.ngtlib.io.NGTLog
+import jp.ngt.ngtlib.io.ScriptUtil
+import jp.ngt.rtm.entity.train.EntityTrainBase
+import jp.ngt.rtm.modelpack.ModelPackManager
+import jp.ngt.rtm.modelpack.cfg.TrainConfig
+import jp.ngt.rtm.modelpack.modelset.ModelSetVehicleBase
+import java.util.concurrent.ConcurrentHashMap
+
+object TrainProtectionPluginManager {
+    private val entries: MutableMap<String, Entry> = ConcurrentHashMap()
+
+    init {
+        putProtectionPlugin(
+            RtmDefaultTrainProtectionPlugin.ID,
+            RtmDefaultTrainProtectionPlugin.DISPLAY_NAME,
+            RtmDefaultTrainProtectionPlugin,
+            defaultEnabled = true,
+        )
+    }
+
+    @JvmStatic
+    fun register(config: TrainProtectionPluginConfig) {
+        config.checkFields()
+
+        entries[config.id] = Entry(
+            id = config.id,
+            displayName = config.displayName,
+            defaultEnabled = config.defaultEnabled,
+            plugin = createPlugin(config),
+        )
+    }
+
+    @JvmStatic
+    fun enableDefaultPlugins(train: EntityTrainBase) {
+        for (id in getDefaultPluginIds(train)) {
+            enablePlugin(train, id)
+        }
+    }
+
+    private fun enablePlugin(train: EntityTrainBase, id: String) {
+        if (train.hasProtectionPlugin(id)) {
+            return
+        }
+
+        try {
+            train.enableProtectionPlugin(id)
+        } catch (e: Exception) {
+            NGTLog.debug("[RTM] Failed to enable train protection plugin: $id")
+            e.printStackTrace()
+        }
+    }
+
+    private fun getDefaultPluginIds(train: EntityTrainBase): List<String> {
+        if (entries.isEmpty()) {
+            return emptyList()
+        }
+
+        val modelSet: ModelSetVehicleBase<TrainConfig> = train.getModelSet()
+        if (modelSet.isDummy) {
+            return emptyList()
+        }
+
+        return entries.values
+            .filter { it.defaultEnabled }
+            .sortedBy { it.id }
+            .map { it.id }
+    }
+
+    @JvmStatic
+    @JvmOverloads
+    fun registerJsProtectionPlugin(id: String, jsPlugin: Any?, defaultEnabled: Boolean = false): Boolean {
+        return putProtectionPlugin(id, id, ScriptTrainProtectionPlugin.create(jsPlugin), defaultEnabled)
+    }
+
+    @JvmStatic
+    fun registerProtectionPlugin(id: String, plugin: TrainProtectionPlugin, defaultEnabled: Boolean): Boolean {
+        return putProtectionPlugin(id, id, plugin, defaultEnabled)
+    }
+
+    private fun putProtectionPlugin(
+        id: String,
+        displayName: String,
+        plugin: TrainProtectionPlugin,
+        defaultEnabled: Boolean,
+    ): Boolean {
+        if (id.isEmpty()) {
+            return false
+        }
+        entries[id] = Entry(
+            id = id,
+            displayName = displayName,
+            defaultEnabled = defaultEnabled,
+            plugin = plugin
+        )
+        return true
+    }
+
+    @JvmStatic
+    fun getPlugin(id: String): TrainProtectionPlugin? {
+        return entries[id]?.plugin
+    }
+
+    private fun createPlugin(config: TrainProtectionPluginConfig): TrainProtectionPlugin {
+        return ScriptTrainProtectionPlugin.create(ScriptUtil.doScript(ModelPackManager.INSTANCE.getScript(config.scriptPath)))
+    }
+
+    private data class Entry(
+        val id: String,
+        val displayName: String,
+        val defaultEnabled: Boolean,
+        val plugin: TrainProtectionPlugin
+    )
+}

--- a/src/main/java/jp/ngt/rtm/entity/train/protection/TrainProtectionPluginManager.kt
+++ b/src/main/java/jp/ngt/rtm/entity/train/protection/TrainProtectionPluginManager.kt
@@ -2,14 +2,20 @@ package jp.ngt.rtm.entity.train.protection
 
 import jp.ngt.ngtlib.io.NGTLog
 import jp.ngt.ngtlib.io.ScriptUtil
+import jp.ngt.rtm.RTMCore
 import jp.ngt.rtm.entity.train.EntityTrainBase
 import jp.ngt.rtm.modelpack.ModelPackManager
 import jp.ngt.rtm.modelpack.cfg.TrainConfig
 import jp.ngt.rtm.modelpack.modelset.ModelSetVehicleBase
+import jp.ngt.rtm.network.PacketTrainProtectionPluginList
+import net.minecraft.entity.player.EntityPlayerMP
 import java.util.concurrent.ConcurrentHashMap
 
 object TrainProtectionPluginManager {
     private val entries: MutableMap<String, Entry> = ConcurrentHashMap()
+
+    @Volatile
+    private var syncedPluginInfos: List<TrainProtectionPluginInfo> = emptyList()
 
     init {
         putProtectionPlugin(
@@ -36,6 +42,15 @@ object TrainProtectionPluginManager {
     fun enableDefaultPlugins(train: EntityTrainBase) {
         for (id in getDefaultPluginIds(train)) {
             enablePlugin(train, id)
+        }
+    }
+
+    @JvmStatic
+    fun enableSavedPlugins(train: EntityTrainBase) {
+        for (info in getLocalPluginInfos()) {
+            if (train.isProtectionPluginEnabled(info.id)) {
+                enablePlugin(train, info.id)
+            }
         }
     }
 
@@ -100,6 +115,27 @@ object TrainProtectionPluginManager {
     @JvmStatic
     fun getPlugin(id: String): TrainProtectionPlugin? {
         return entries[id]?.plugin
+    }
+
+    @JvmStatic
+    fun getPluginInfos(): List<TrainProtectionPluginInfo> {
+        return syncedPluginInfos
+    }
+
+    @JvmStatic
+    fun setSyncedPluginInfos(pluginInfos: List<TrainProtectionPluginInfo>) {
+        syncedPluginInfos = pluginInfos.sortedBy { it.id }
+    }
+
+    @JvmStatic
+    fun sendPluginInfos(player: EntityPlayerMP) {
+        RTMCore.NETWORK_WRAPPER.sendTo(PacketTrainProtectionPluginList(getLocalPluginInfos()), player)
+    }
+
+    private fun getLocalPluginInfos(): List<TrainProtectionPluginInfo> {
+        return entries.values
+            .sortedBy { it.id }
+            .map { TrainProtectionPluginInfo(it.id, it.displayName, it.defaultEnabled) }
     }
 
     private fun createPlugin(config: TrainProtectionPluginConfig): TrainProtectionPlugin {

--- a/src/main/java/jp/ngt/rtm/entity/train/util/TrainSpeedManager.java
+++ b/src/main/java/jp/ngt/rtm/entity/train/util/TrainSpeedManager.java
@@ -7,6 +7,13 @@ import jp.ngt.rtm.modelpack.cfg.TrainConfig;
 public final class TrainSpeedManager {
     private static final float[] BRAKE = {-0.0005F, -0.001F, -0.0015F, -0.002F, -0.0025F, -0.003F, -0.0035F, -0.01F};
 
+    public static int clampBrakeNotch(int notch, TrainConfig cfg) {
+        if (notch >= 0) {
+            return 0;
+        }
+        return -Math.min(cfg.deccelerations.length - 1, -notch);
+    }
+
     public static float getAcceleration(EntityTrainBase train, int notch, float prevSpeed, TrainConfig cfg) {
         if (notch == 0) {
             return 0.0F;
@@ -20,7 +27,8 @@ public final class TrainSpeedManager {
                             train.getModelSet().serverSE,
                             "getAcceleration",
                             train,
-                            prevSpeed);
+                            prevSpeed,
+                            notch);
                     return obj != null ? Float.parseFloat(obj.toString()) : 0.0f;
                 } else {
                     return cfg.accelerateions[Math.min(cfg.accelerateions.length - 1, notch)];
@@ -33,7 +41,8 @@ public final class TrainSpeedManager {
                         train.getModelSet().serverSE,
                         "getDeceleration",
                         train,
-                        prevSpeed);
+                        prevSpeed,
+                        notch);
                 deceleration = obj != null ? Float.parseFloat(obj.toString()) : 0.0f;
             } else {
                 deceleration = cfg.deccelerations[Math.min(cfg.deccelerations.length - 1, -notch)];

--- a/src/main/java/jp/ngt/rtm/entity/train/util/TrainSpeedManager.java
+++ b/src/main/java/jp/ngt/rtm/entity/train/util/TrainSpeedManager.java
@@ -18,8 +18,7 @@ public final class TrainSpeedManager {
         if (notch == 0) {
             return 0.0F;
         } else if (notch > 0) {
-            --notch;
-            if (prevSpeed >= cfg.maxSpeed[Math.min(cfg.maxSpeed.length - 1, notch)]) {
+            if (prevSpeed >= cfg.maxSpeed[Math.min(cfg.maxSpeed.length - 1, notch - 1)]) {
                 return 0.0F;
             } else {
                 if (cfg.useVariableAcceleration) {
@@ -31,7 +30,7 @@ public final class TrainSpeedManager {
                             notch);
                     return obj != null ? Float.parseFloat(obj.toString()) : 0.0f;
                 } else {
-                    return cfg.accelerateions[Math.min(cfg.accelerateions.length - 1, notch)];
+                    return cfg.accelerateions[Math.min(cfg.accelerateions.length - 1, notch - 1)];
                 }
             }
         } else {

--- a/src/main/java/jp/ngt/rtm/entity/train/util/TrainState.java
+++ b/src/main/java/jp/ngt/rtm/entity/train/util/TrainState.java
@@ -46,6 +46,7 @@ public enum TrainState {
         State_TrainDir(0, "train_dir", 0, 1),
         State_Notch(1, "notch", -8, 5),
         State_Signal(2, "signal", -1, 127),//6
+        State_InternalNotch(3, "internal_notch", -128, 127),
         State_Door(4, "door", 0, 3),
         State_Light(5, "light", 0, 2),
         State_Pantograph(6, "pantograph", 0, 1),

--- a/src/main/java/jp/ngt/rtm/event/RTMKeyHandlerServer.java
+++ b/src/main/java/jp/ngt/rtm/event/RTMKeyHandlerServer.java
@@ -37,8 +37,8 @@ public final class RTMKeyHandlerServer {
             }
         } else if (keyCode == RTMCore.KEY_ATS) {
             EntityTrainBase train = this.getRidingTrain(player);
-            if (train == null || !train.onProtectionPluginATSKeyDown(player)) {
-                this.setATS(player);
+            if (train != null) {
+                train.onProtectionPluginATSKeyDown(player);
             }
         }
     }
@@ -67,18 +67,6 @@ public final class RTMKeyHandlerServer {
                 } else {
                     RTMCore.proxy.playSound(train, new ResourceLocation(sa[0], sa[1]), vol, 1.0F, range);
                 }
-            }
-        }
-    }
-
-    private void setATS(EntityPlayer player) {
-        EntityTrainBase train = this.getRidingTrain(player);
-        if (train != null) {
-            int signal = train.getSignal();
-            if (signal == 1) {
-                train.setSignal2(-1);
-            } else if (signal == -1 && train.getNotch() == -8) {
-                train.setSignal2(0);
             }
         }
     }

--- a/src/main/java/jp/ngt/rtm/event/RTMKeyHandlerServer.java
+++ b/src/main/java/jp/ngt/rtm/event/RTMKeyHandlerServer.java
@@ -36,7 +36,10 @@ public final class RTMKeyHandlerServer {
                 ((EntityArtillery) player.ridingEntity).onFireKeyDown(player);
             }
         } else if (keyCode == RTMCore.KEY_ATS) {
-            this.setATS(player);
+            EntityTrainBase train = this.getRidingTrain(player);
+            if (train == null || !train.onProtectionPluginATSKeyDown(player)) {
+                this.setATS(player);
+            }
         }
     }
 

--- a/src/main/java/jp/ngt/rtm/gui/ContainerTrainControlPanel.java
+++ b/src/main/java/jp/ngt/rtm/gui/ContainerTrainControlPanel.java
@@ -1,7 +1,9 @@
 package jp.ngt.rtm.gui;
 
 import jp.ngt.rtm.entity.train.EntityTrainBase;
+import jp.ngt.rtm.entity.train.protection.TrainProtectionPluginManager;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.inventory.ContainerPlayer;
 import net.minecraft.inventory.Slot;
 
@@ -19,6 +21,9 @@ public class ContainerTrainControlPanel extends ContainerPlayer {
         this.train = par1;
         this.player = par2;
         this.slotsList = this.inventorySlots;
+        if (!par2.worldObj.isRemote && par2 instanceof EntityPlayerMP) {
+            TrainProtectionPluginManager.sendPluginInfos((EntityPlayerMP) par2);
+        }
     }
 
     @Override

--- a/src/main/java/jp/ngt/rtm/gui/GuiTrainControlPanel.java
+++ b/src/main/java/jp/ngt/rtm/gui/GuiTrainControlPanel.java
@@ -2,23 +2,19 @@ package jp.ngt.rtm.gui;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
-import jp.kaiz.kaizpatch.gui.GuiButtonWithScrollingListBox;
 import jp.ngt.rtm.RTMCore;
 import jp.ngt.rtm.entity.npc.macro.MacroRecorder;
 import jp.ngt.rtm.entity.train.EntityTrainBase;
-import jp.ngt.rtm.entity.train.util.Formation;
-import jp.ngt.rtm.entity.train.util.FormationEntry;
 import jp.ngt.rtm.entity.train.util.TrainState;
 import jp.ngt.rtm.entity.train.util.TrainState.TrainStateType;
 import jp.ngt.rtm.modelpack.cfg.TrainConfig;
 import jp.ngt.rtm.modelpack.modelset.ModelSetVehicleBase;
-import jp.ngt.rtm.modelpack.modelset.ModelSetVehicleBaseClient;
 import jp.ngt.rtm.modelpack.state.DataMap;
 import jp.ngt.rtm.network.PacketNotice;
-import kotlin.Unit;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.gui.GuiButton;
+import net.minecraft.client.gui.ScaledResolution;
 import net.minecraft.client.gui.achievement.GuiAchievements;
 import net.minecraft.client.gui.achievement.GuiStats;
 import net.minecraft.client.gui.inventory.GuiInventory;
@@ -32,22 +28,16 @@ import net.minecraft.inventory.Container;
 import net.minecraft.inventory.Slot;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
-import org.lwjgl.input.Keyboard;
 import org.lwjgl.input.Mouse;
 import org.lwjgl.opengl.GL11;
 import org.lwjgl.opengl.GL12;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Objects;
-import java.util.stream.Collectors;
+import java.util.*;
 import java.util.stream.IntStream;
 
 @SideOnly(Side.CLIENT)
 public class GuiTrainControlPanel extends InventoryEffectRenderer {
     private static final ResourceLocation tabTexture = new ResourceLocation("textures/gui/container/creative_inventory/tabs.png");
-    private static final int CUSTOM_BUTTOM_ID = 2000;
 
     private int selectedTabIndex = TabTrainControlPanel.TAB_Inventory.getTabIndex();
     /**
@@ -66,15 +56,12 @@ public class GuiTrainControlPanel extends InventoryEffectRenderer {
      */
     private static int tabPage = 0;
     private int maxPages = 0;
+    private final Map<Integer, TrainControlPanelPage> pages = new HashMap<>();
 
     protected final EntityTrainBase train;
     protected final EntityPlayer player;
     protected final ModelSetVehicleBase<TrainConfig> modelset;
 
-    private GuiButton buttonChunkLoader;
-    private GuiButtonWithScrollingListBox buttonDestination;
-    private GuiButtonWithScrollingListBox buttonAnnouncement;
-    private final GuiButton[] buttonDirection = new GuiButton[3];
     /**
      * 0:R, L:1
      */
@@ -87,6 +74,10 @@ public class GuiTrainControlPanel extends InventoryEffectRenderer {
         this.modelset = par1.train.getModelSet();
         this.player.openContainer = this.inventorySlots;
         this.allowUserInput = true;
+        this.pages.put(TabTrainControlPanel.TAB_Setting.getTabIndex(), new TrainControlPanelSettingPage(this));
+        this.pages.put(TabTrainControlPanel.TAB_Function.getTabIndex(), new TrainControlPanelFunctionPage(this));
+        this.pages.put(TabTrainControlPanel.TAB_Protection.getTabIndex(), new TrainControlPanelProtectionPage(this));
+        this.pages.put(TabTrainControlPanel.TAB_Formation.getTabIndex(), new TrainControlPanelFormationPage(this));
     }
 
     @Override
@@ -133,102 +124,14 @@ public class GuiTrainControlPanel extends InventoryEffectRenderer {
 
         if (tab == TabTrainControlPanel.TAB_Inventory) {
             containerTrain.inventorySlots = this.slotsList;
-
             this.buttonList.clear();
-        } else if (tab == TabTrainControlPanel.TAB_Setting) {
+        } else {
             this.initInventorySlot(containerTrain);
-
             this.buttonList.clear();
-            //wMax:168
-            TrainStateType t0 = TrainStateType.State_InteriorLight;
-            this.buttonList.add(new GuiButton(124, this.guiLeft + 4, this.guiTop + 4, 82, 20, this.getFormattedText(t0.id, this.train.getTrainStateData(t0.id))));
-            this.buttonList.add(new GuiButton(125, this.guiLeft + 90, this.guiTop + 4, 82, 20, this.getFormattedText(5, this.train.getTrainStateData(5))));
-            this.buttonList.add(new GuiButton(126, this.guiLeft + 4, this.guiTop + 28, 82, 20, this.getFormattedText(6, this.train.getTrainStateData(6))));
-
-            int i0 = this.train.getTrainStateData(TrainStateType.State_Direction.id);
-            IntStream.range(0, 3).forEach(j -> {
-                this.buttonDirection[j] = new GuiButton(140 + j, this.guiLeft + 91 + 27 * j, this.guiTop + 28, 27, 20, this.getFormattedText(TrainStateType.State_Direction.id, (byte) j));
-                this.buttonList.add(this.buttonDirection[j]);
-                if (j == i0) {
-                    this.buttonDirection[j].enabled = false;
-                }
-            });
-            /*this.buttonList.add(new GuiButton(140, this.guiLeft + 91, this.guiTop + 28, 27, 20, this.getFormattedText(EnumTrainStateType.State_Direction.id, (byte)0)));
-            this.buttonList.add(new GuiButton(141, this.guiLeft + 118, this.guiTop + 28, 27, 20, this.getFormattedText(EnumTrainStateType.State_Direction.id, (byte)1)));
-            this.buttonList.add(new GuiButton(142, this.guiLeft + 145, this.guiTop + 28, 27, 20, this.getFormattedText(EnumTrainStateType.State_Direction.id, (byte)2)));*/
-
-            this.buttonChunkLoader = new GuiButton(127, this.guiLeft + 28, this.guiTop + 52, 120, 20, this.getFormattedText(7, this.train.getTrainStateData(7)));
-            this.buttonList.add(this.buttonChunkLoader);
-            this.buttonList.add(new GuiButton(110, this.guiLeft + 4, this.guiTop + 52, 20, 20, "<"));
-            this.buttonList.add(new GuiButton(111, this.guiLeft + 152, this.guiTop + 52, 20, 20, ">"));
-
-            if (((ModelSetVehicleBaseClient<TrainConfig>) this.modelset).rollsignTexture != null) {
-                this.buttonDestination = new GuiButtonWithScrollingListBox(128, this.guiLeft + 28, this.guiTop + 76, 120, 20,
-                        () -> (int) this.train.getTrainStateData(8),
-                        Arrays.asList(this.modelset.getConfig().rollsignNames),
-                        I18n.format("state.destination") + " %s",
-                        data -> {
-                            this.sendTrainState(8, data.byteValue());
-                            return Unit.INSTANCE;
-                        });
-                this.buttonList.add(this.buttonDestination);
-                this.buttonList.add(new GuiButton(112, this.guiLeft + 4, this.guiTop + 76, 20, 20, "<"));
-                this.buttonList.add(new GuiButton(113, this.guiLeft + 152, this.guiTop + 76, 20, 20, ">"));
+            TrainControlPanelPage page = this.getActivePage();
+            if (page != null) {
+                page.init();
             }
-
-            if (this.modelset.getConfig().sound_Announcement != null) {
-                this.buttonAnnouncement = new GuiButtonWithScrollingListBox(129, this.guiLeft + 28, this.guiTop + 100, 120, 20,
-                        () -> (int) this.train.getTrainStateData(9),
-                        Arrays.stream(this.modelset.getConfig().sound_Announcement).map(s -> s[0]).collect(Collectors.toList()),
-                        I18n.format("state.announcement") + " %s",
-                        data -> {
-                            this.sendTrainState(9, data.byteValue());
-                            return Unit.INSTANCE;
-                        });
-                this.buttonList.add(this.buttonAnnouncement);
-                this.buttonList.add(new GuiButton(114, this.guiLeft + 4, this.guiTop + 100, 20, 20, "<"));
-                this.buttonList.add(new GuiButton(115, this.guiLeft + 152, this.guiTop + 100, 20, 20, ">"));
-            }
-        } else if (tab == TabTrainControlPanel.TAB_Function) {
-            this.initInventorySlot(containerTrain);
-
-            this.buttonList.clear();
-
-            String[][] buttons = this.getCustomButtons();
-            String[] tips = this.getCustomButtonTips();
-            IntStream.range(0, buttons.length).forEach(i -> {
-                int x = this.guiLeft + 4 + (i % 3) * (54 + 3);
-                int y = this.guiTop + 4 + (i / 3) * (20 + 4);
-                GuiButtonWithScrollingListBox button = new GuiButtonWithScrollingListBox(CUSTOM_BUTTOM_ID + i, x, y, 54, 20,
-                        () -> this.getDataMap().getInt("Button" + i),
-                        Arrays.stream(buttons[i]).collect(Collectors.toList()),
-                        "%s",
-                        data -> {
-                            this.getDataMap().setInt("Button" + i, data, 3);
-                            return Unit.INSTANCE;
-                        });
-                button.addTips(tips[i]);
-                this.buttonList.add(button);
-            });
-        } else if (tab == TabTrainControlPanel.TAB_Formation) {
-            this.initInventorySlot(containerTrain);
-
-            this.buttonList.clear();
-
-            Formation formation = this.train.getFormation();
-            if (formation != null) {
-                IntStream.range(0, formation.size()).forEach(i -> {
-                    FormationEntry entry = formation.get(i);
-                    if (entry == null) {
-                        return;
-                    }
-                    int v = i == 0 ? 0 : (i == formation.size() - 1 ? 2 : 1);
-                    int x = this.guiLeft + 8 + (i % 5) * 32;
-                    int y = this.guiTop + 25 + (i / 5) * 32;
-                    this.buttonList.add(new GuiButtonFormation(200 + i, entry, x, y, v));
-                });
-            }
-            //Screen:162*128
         }
 
         this.buttonDoor[0] = new GuiButtonDoor(300, this.guiLeft + this.xSize + 20, this.guiTop + 20, 64, 80);
@@ -291,6 +194,11 @@ public class GuiTrainControlPanel extends InventoryEffectRenderer {
                     return;
                 }
             }
+
+            TrainControlPanelPage page = this.getActivePage();
+            if (page != null && page.mouseClicked(par1, par2, par3)) {
+                return;
+            }
         } else if (par3 == 1) {
             for (Object o : this.buttonList) {
                 GuiButton guibutton = (GuiButton) o;
@@ -351,57 +259,10 @@ public class GuiTrainControlPanel extends InventoryEffectRenderer {
             //((ContainerTrainControlPanel)this.inventorySlots).scrollTo(this.currentScroll);
         }
         if (i != 0) {
-            int i0 = (i > 0) ? -1 : 1;
-            ((List<GuiButton>) this.buttonList).stream()
-                    .filter(GuiButton::func_146115_a)
-                    .findFirst()
-                    .ifPresent(button -> {
-                        int id, data, prevData;
-                        if (button.id >= 124 && button.id <= 129) {
-                            id = button.id - 120;
-                            if (button.id == 124) {
-                                id = TrainStateType.State_InteriorLight.id;
-                            }
-                            prevData = this.train.getTrainStateData(id);
-                            data = prevData + i0;
-                        } else if (button.id >= CUSTOM_BUTTOM_ID) {
-                            int index = button.id - CUSTOM_BUTTOM_ID;
-                            String[] sa = this.getCustomButtons()[index];
-                            int nowValue = this.getDataMap().getInt("Button" + index);
-                            int val = nowValue + i0;
-                            if (val >= sa.length) {
-                                val = 0;
-                            } else if (val < 0) {
-                                val = sa.length - 1;
-                            }
-                            button.func_146113_a(this.mc.getSoundHandler());
-                            this.getDataMap().setInt("Button" + index, val, 3);
-                            return;
-                        } else {
-                            return;
-                        }
-
-                        TrainStateType stateType = TrainState.getStateType(id);
-                        int min, max;
-                        if (stateType == TrainStateType.State_Destination) {
-                            String[] rollSignNames = this.modelset.getConfig().rollsignNames;
-                            min = 0;
-                            max = rollSignNames != null ? rollSignNames.length - 1 : 0;
-                        } else if (stateType == TrainStateType.State_Announcement) {
-                            String[][] announce = this.modelset.getConfig().sound_Announcement;
-                            min = 0;
-                            max = announce != null ? announce.length - 1 : 0;
-                        } else {
-                            min = stateType.min;
-                            max = stateType.max;
-                        }
-                        data = data < min ? max : data > max ? min : data;
-                        if (prevData != data) {
-                            this.sendTrainState(id, (byte) data);
-                            button.func_146113_a(this.mc.getSoundHandler());
-                            button.displayString = this.getFormattedText(id, (byte) data);
-                        }
-                    });
+            TrainControlPanelPage page = this.getActivePage();
+            if (page != null && page.handleMouseWheel(i)) {
+                return;
+            }
         }
     }
 
@@ -436,6 +297,10 @@ public class GuiTrainControlPanel extends InventoryEffectRenderer {
         }
 
         super.drawScreen(par1, par2, par3);
+        TrainControlPanelPage activePage = this.getActivePage();
+        if (activePage != null) {
+            activePage.drawScreen(par1, par2, par3);
+        }
 
         TabTrainControlPanel[] tabs = TabTrainControlPanel.tabArray;
         int start = tabPage * 10;
@@ -474,23 +339,9 @@ public class GuiTrainControlPanel extends InventoryEffectRenderer {
     @Override
     protected void keyTyped(char par1, int par2) {
         super.keyTyped(par1, par2);
-        if (par2 == Keyboard.KEY_F) {
-            ((List<GuiButton>) this.buttonList).stream()
-                    .filter(button -> button.id >= CUSTOM_BUTTOM_ID)
-                    .filter(GuiButton::func_146115_a)
-                    .findFirst()
-                    .ifPresent(button -> {
-                        int index = button.id - CUSTOM_BUTTOM_ID;
-                        int val = this.getDataMap().getInt("Button" + index);
-
-                        Formation formation = this.train.getFormation();
-                        if (formation != null) {
-                            formation.getTrainStream()
-                                    .filter(Objects::nonNull)
-                                    .forEach(train -> train.getResourceState().getDataMap().setInt("Button" + index, val, 3));
-                            button.func_146113_a(this.mc.getSoundHandler());
-                        }
-                    });
+        TrainControlPanelPage page = this.getActivePage();
+        if (page != null) {
+            page.keyTyped(par1, par2);
         }
     }
 
@@ -686,76 +537,10 @@ public class GuiTrainControlPanel extends InventoryEffectRenderer {
             tabPage = Math.min(tabPage + 1, maxPages);
         }
 
-        if ((button.id >= 110 && button.id <= 115) || (button.id >= 124 && button.id <= 129) || (button.id >= 140 && button.id <= 142)) {
-            int i0;
-            int i1;
-
-            if (button.id == 110)//ChunkLoader
-            {
-                i0 = 7;
-                i1 = this.train.getTrainStateData(i0) - 1;
-            } else if (button.id == 111)//ChunkLoader
-            {
-                i0 = 7;
-                i1 = this.train.getTrainStateData(i0) + 1;
-            } else if (button.id == 112)//行先
-            {
-                i0 = 8;
-                i1 = this.train.getTrainStateData(i0) - 1;
-                if (i1 < 0) {
-                    i1 = this.modelset.getConfig().rollsignNames.length - 1;
-                }
-            } else if (button.id == 113)//行先
-            {
-                i0 = 8;
-                i1 = this.train.getTrainStateData(i0) + 1;
-                if (i1 >= this.modelset.getConfig().rollsignNames.length) {
-                    i1 = 0;
-                }
-            } else if (button.id == 114)//車内放送
-            {
-                String[][] announce = (this.modelset.getConfig()).sound_Announcement;
-                i0 = 9;
-                i1 = this.train.getTrainStateData(i0) - 1;
-                if (announce != null && i1 < 0) {
-                    i1 = announce.length - 1;
-                }
-            } else if (button.id == 115)//車内放送
-            {
-                String[][] announce = (this.modelset.getConfig()).sound_Announcement;
-                i0 = 9;
-                i1 = this.train.getTrainStateData(i0) + 1;
-                if (announce != null && i1 >= announce.length) {
-                    i1 = 0;
-                }
-            } else if (button.id == 128) {
+        TrainControlPanelPage page = this.getActivePage();
+        if (page != null) {
+            if (page.actionPerformed(button)) {
                 return;
-            } else if (button.id == 129) {
-                return;
-            } else if (button.id <= 129) {
-                i0 = button.id - 120;
-                if (button.id == 124) {
-                    i0 = TrainStateType.State_InteriorLight.id;
-                }
-                i1 = this.train.getTrainStateData(i0) + 1;
-            } else {
-                i0 = TrainStateType.State_Direction.id;
-                i1 = button.id - 140;
-                for (int i = 0; i < 3; ++i) {
-                    this.buttonDirection[i].enabled = i != i1;
-                }
-            }
-
-            TrainStateType stateType = TrainState.getStateType(i0);
-            int i2 = i1 < stateType.min ? stateType.max : (i1 > stateType.max ? stateType.min : i1);
-            this.sendTrainState(i0, (byte) i2);
-
-            if (button.id == 110 || button.id == 111) {
-                this.buttonChunkLoader.displayString = this.getFormattedText(i0, (byte) i2);
-            } else if (button.id == 112 || button.id == 113) {
-            } else if (button.id == 114 || button.id == 115) {
-            } else {
-                button.displayString = this.getFormattedText(i0, (byte) i2);
             }
         }
 
@@ -789,7 +574,7 @@ public class GuiTrainControlPanel extends InventoryEffectRenderer {
         }
     }
 
-    private void sendTrainState(int id, byte data) {
+    public void sendTrainState(int id, byte data) {
         this.train.syncTrainStateData(id, data);
     }
 
@@ -817,63 +602,97 @@ public class GuiTrainControlPanel extends InventoryEffectRenderer {
         }
     }
 
-    private DataMap getDataMap() {
+    public EntityTrainBase getPanelTrain() {
+        return this.train;
+    }
+
+    public EntityPlayer getPanelPlayer() {
+        return this.player;
+    }
+
+    public ModelSetVehicleBase<TrainConfig> getPanelModelSet() {
+        return this.modelset;
+    }
+
+    public Minecraft getPanelMinecraft() {
+        return this.mc;
+    }
+
+    public FontRenderer getPanelFontRenderer() {
+        return this.fontRendererObj;
+    }
+
+    public int getPanelLeft() {
+        return this.guiLeft;
+    }
+
+    public int getPanelTop() {
+        return this.guiTop;
+    }
+
+    public int getPanelWidth() {
+        return this.xSize;
+    }
+
+    public int getPanelHeight() {
+        return this.ySize;
+    }
+
+    public int getScreenWidth() {
+        return this.width;
+    }
+
+    public int getScreenHeight() {
+        return this.height;
+    }
+
+    @SuppressWarnings("unchecked")
+    public List<GuiButton> getPanelButtons() {
+        return (List<GuiButton>) this.buttonList;
+    }
+
+    public void addPanelButton(GuiButton button) {
+        this.buttonList.add(button);
+    }
+
+    public DataMap getPanelDataMap() {
         return this.train.getResourceState().getDataMap();
     }
 
-    private String[][] getCustomButtons() {
+    public String[][] getCustomButtons() {
         return this.modelset.getConfig().customButtons;
     }
 
-    private String[] getCustomButtonTips() {
+    public String[] getCustomButtonTips() {
         return this.modelset.getConfig().customButtonTips;
     }
 
-    private class GuiButtonFormation extends GuiButton {
-        private final FormationEntry car;
-        private final int v;
+    public void sendProtectionPluginState(String id, boolean enabled) {
+        String message = "setTrainProtectionPlugin," + id + "," + enabled;
+        RTMCore.NETWORK_WRAPPER.sendToServer(new PacketNotice(PacketNotice.Side_SERVER, message, this.train));
+    }
 
-        public GuiButtonFormation(int id, FormationEntry entry, int posX, int posY, int posV) {
-            super(id, posX, posY, 32, 16, String.valueOf(entry.entryId + 1));
-            this.car = entry;
-            this.v = posV;
+    public void playPanelClickSound() {
+        if (this.mc.thePlayer != null) {
+            this.mc.thePlayer.playSound("random.click", 1.0F, 1.0F);
         }
+    }
 
-        @Override
-        public void drawButton(Minecraft mc, int x, int y) {
-            if (!this.visible) {
-                return;
-            }
+    public void drawPanelRect(int left, int top, int right, int bottom, int color) {
+        drawRect(left, top, right, bottom, color);
+    }
 
-            mc.getTextureManager().bindTexture(TabTrainControlPanel.TAB_Formation.getTexture());
-            GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
-            GL11.glEnable(GL11.GL_ALPHA_TEST);
-            int u = this.car.train.isControlCar() ? 1 : 0;
-            this.field_146123_n = x >= this.xPosition && y >= this.yPosition && x < this.xPosition + this.width && y < this.yPosition + this.height;
-            this.drawTexturedModalRect(this.xPosition, this.yPosition, 192 + u * 32, this.v * 16, this.width, this.height);
-            this.mouseDragged(mc, x, y);
+    public void drawPanelCenteredString(String text, int x, int y, int color) {
+        this.drawCenteredString(this.fontRendererObj, text, x, y, color);
+    }
 
-            //プレーヤー位置の矢印
-            if (this.car.train.riddenByEntity == mc.thePlayer) {
-                this.drawTexturedModalRect(this.xPosition + 12, this.yPosition - 16, 180, 0, 10, 16);
-            }
+    public void enableGuiScissor(int x, int y, int width, int height) {
+        ScaledResolution resolution = new ScaledResolution(this.mc, this.mc.displayWidth, this.mc.displayHeight);
+        int scale = resolution.getScaleFactor();
+        GL11.glScissor(x * scale, (this.height - y - height) * scale, width * scale, height * scale);
+    }
 
-            this.drawCenteredString(mc.fontRenderer, this.displayString, this.xPosition + this.width / 2, this.yPosition + 2, 0x000000);
-        }
-
-        @Override
-        public boolean mousePressed(Minecraft mx, int x, int y) {
-            if (super.mousePressed(mc, x, y)) {
-                if (y - this.yPosition < 12) {
-                } else {
-                    if (x - this.xPosition < 12) {
-                        //台車クリックで連結解除
-                    } else {
-                    }
-                }
-                return true;
-            }
-            return false;
-        }
+    private TrainControlPanelPage getActivePage() {
+        return this.pages.get(this.selectedTabIndex);
     }
 }

--- a/src/main/java/jp/ngt/rtm/gui/TabTrainControlPanel.java
+++ b/src/main/java/jp/ngt/rtm/gui/TabTrainControlPanel.java
@@ -21,6 +21,7 @@ public class TabTrainControlPanel {
     public static final TabTrainControlPanel TAB_Inventory = new TabTrainControlPanel("Player_Inventory", Item.getItemFromBlock(Blocks.chest), new ResourceLocation("rtm", "textures/gui/tab_inventory.png"));
     public static final TabTrainControlPanel TAB_Setting = new TabTrainControlPanel("Setting", RTMItem.crowbar, new ResourceLocation("rtm", "textures/gui/tab_setting.png"));
     public static final TabTrainControlPanel TAB_Function = new TabTrainControlPanel("Function", RTMItem.wrench, new ResourceLocation("rtm", "textures/gui/tab_setting.png"));
+    public static final TabTrainControlPanel TAB_Protection = new TabTrainControlPanel("Protection", RTMItem.itemSignal, new ResourceLocation("rtm", "textures/gui/tab_setting.png"));
     public static final TabTrainControlPanel TAB_Formation = new TabTrainControlPanel("Formation", RTMItem.itemtrain, new ResourceLocation("rtm", "textures/gui/tab_formation.png"));
 
     public TabTrainControlPanel(String par1, Item par2, ResourceLocation par3) {

--- a/src/main/java/jp/ngt/rtm/gui/TrainControlPanelFormationPage.kt
+++ b/src/main/java/jp/ngt/rtm/gui/TrainControlPanelFormationPage.kt
@@ -1,0 +1,52 @@
+package jp.ngt.rtm.gui
+
+import jp.ngt.rtm.entity.train.util.FormationEntry
+import net.minecraft.client.Minecraft
+import net.minecraft.client.gui.GuiButton
+import org.lwjgl.opengl.GL11
+
+class TrainControlPanelFormationPage(gui: GuiTrainControlPanel) : TrainControlPanelPage(gui) {
+    override fun init() {
+        val formation = gui.panelTrain.formation ?: return
+        for (i in 0 until formation.size()) {
+            val entry = formation[i] ?: continue
+            val v = if (i == 0) 0 else if (i == formation.size() - 1) 2 else 1
+            val x = gui.panelLeft + 8 + (i % 5) * 32
+            val y = gui.panelTop + 25 + (i / 5) * 32
+            gui.addPanelButton(TrainFormationButton(200 + i, entry, x, y, v))
+        }
+    }
+}
+
+private class TrainFormationButton(
+    id: Int,
+    private val car: FormationEntry,
+    posX: Int,
+    posY: Int,
+    private val v: Int
+) : GuiButton(id, posX, posY, 32, 16, (car.entryId + 1).toString()) {
+    override fun drawButton(mc: Minecraft, mouseX: Int, mouseY: Int) {
+        if (!visible) {
+            return
+        }
+
+        mc.textureManager.bindTexture(TabTrainControlPanel.TAB_Formation.texture)
+        GL11.glColor4f(1.0f, 1.0f, 1.0f, 1.0f)
+        GL11.glEnable(GL11.GL_ALPHA_TEST)
+        val u = if (car.train.isControlCar) 1 else 0
+        field_146123_n =
+            mouseX >= xPosition && mouseY >= yPosition && mouseX < xPosition + width && mouseY < yPosition + height
+        drawTexturedModalRect(xPosition, yPosition, 192 + u * 32, v * 16, width, height)
+        mouseDragged(mc, mouseX, mouseY)
+
+        if (car.train.riddenByEntity == mc.thePlayer) {
+            drawTexturedModalRect(xPosition + 12, yPosition - 16, 180, 0, 10, 16)
+        }
+
+        drawCenteredString(mc.fontRenderer, displayString, xPosition + width / 2, yPosition + 2, 0x000000)
+    }
+
+    override fun mousePressed(mc: Minecraft, mouseX: Int, mouseY: Int): Boolean {
+        return super.mousePressed(mc, mouseX, mouseY)
+    }
+}

--- a/src/main/java/jp/ngt/rtm/gui/TrainControlPanelFunctionPage.kt
+++ b/src/main/java/jp/ngt/rtm/gui/TrainControlPanelFunctionPage.kt
@@ -1,0 +1,66 @@
+package jp.ngt.rtm.gui
+
+import jp.kaiz.kaizpatch.gui.GuiButtonWithScrollingListBox
+import org.lwjgl.input.Keyboard
+
+class TrainControlPanelFunctionPage(gui: GuiTrainControlPanel) : TrainControlPanelPage(gui) {
+    override fun init() {
+        val buttons = gui.customButtons
+        val tips = gui.customButtonTips
+        for (i in buttons.indices) {
+            val x = gui.panelLeft + 4 + (i % 3) * (54 + 3)
+            val y = gui.panelTop + 4 + (i / 3) * (20 + 4)
+            val button = GuiButtonWithScrollingListBox(
+                CUSTOM_BUTTON_ID + i,
+                x,
+                y,
+                54,
+                20,
+                { gui.panelDataMap.getInt("Button$i") },
+                buttons[i].asList(),
+                "%s"
+            ) {
+                gui.panelDataMap.setInt("Button$i", this, 3)
+            }
+            button.addTips(tips[i])
+            gui.addPanelButton(button)
+        }
+    }
+
+    override fun handleMouseWheel(delta: Int): Boolean {
+        val step = if (delta > 0) -1 else 1
+        val button = gui.panelButtons.firstOrNull { it.func_146115_a() && it.id >= CUSTOM_BUTTON_ID } ?: return false
+        val index = button.id - CUSTOM_BUTTON_ID
+        val values = gui.customButtons[index]
+        var value = gui.panelDataMap.getInt("Button$index") + step
+        if (value >= values.size) {
+            value = 0
+        } else if (value < 0) {
+            value = values.size - 1
+        }
+        button.func_146113_a(gui.panelMinecraft.soundHandler)
+        gui.panelDataMap.setInt("Button$index", value, 3)
+        return true
+    }
+
+    override fun keyTyped(char: Char, keyCode: Int): Boolean {
+        if (keyCode != Keyboard.KEY_F) {
+            return false
+        }
+
+        val button = gui.panelButtons.firstOrNull { it.id >= CUSTOM_BUTTON_ID && it.func_146115_a() } ?: return false
+        val index = button.id - CUSTOM_BUTTON_ID
+        val value = gui.panelDataMap.getInt("Button$index")
+        val formation = gui.panelTrain.formation ?: return true
+
+        formation.trainStream
+            .filter { it != null }
+            .forEach { it.resourceState.dataMap.setInt("Button$index", value, 3) }
+        button.func_146113_a(gui.panelMinecraft.soundHandler)
+        return true
+    }
+
+    companion object {
+        const val CUSTOM_BUTTON_ID = 2000
+    }
+}

--- a/src/main/java/jp/ngt/rtm/gui/TrainControlPanelPage.kt
+++ b/src/main/java/jp/ngt/rtm/gui/TrainControlPanelPage.kt
@@ -1,0 +1,27 @@
+package jp.ngt.rtm.gui
+
+import net.minecraft.client.gui.GuiButton
+
+abstract class TrainControlPanelPage(protected val gui: GuiTrainControlPanel) {
+    open fun init() {
+    }
+
+    open fun actionPerformed(button: GuiButton): Boolean {
+        return false
+    }
+
+    open fun handleMouseWheel(delta: Int): Boolean {
+        return false
+    }
+
+    open fun mouseClicked(mouseX: Int, mouseY: Int, mouseButton: Int): Boolean {
+        return false
+    }
+
+    open fun drawScreen(mouseX: Int, mouseY: Int, partialTicks: Float) {
+    }
+
+    open fun keyTyped(char: Char, keyCode: Int): Boolean {
+        return false
+    }
+}

--- a/src/main/java/jp/ngt/rtm/gui/TrainControlPanelProtectionPage.kt
+++ b/src/main/java/jp/ngt/rtm/gui/TrainControlPanelProtectionPage.kt
@@ -1,0 +1,175 @@
+package jp.ngt.rtm.gui
+
+import jp.ngt.rtm.entity.train.protection.TrainProtectionPluginInfo
+import jp.ngt.rtm.entity.train.protection.TrainProtectionPluginManager
+import org.lwjgl.input.Mouse
+import org.lwjgl.opengl.GL11
+import kotlin.math.max
+import kotlin.math.min
+
+class TrainControlPanelProtectionPage(gui: GuiTrainControlPanel) : TrainControlPanelPage(gui) {
+    private var protectionScroll = 0
+    private var protectionPlugins: List<TrainProtectionPluginInfo> = emptyList()
+
+    override fun init() {
+        refreshProtectionPlugins()
+        protectionScroll = 0
+    }
+
+    override fun mouseClicked(mouseX: Int, mouseY: Int, mouseButton: Int): Boolean {
+        if (mouseButton != 0 || !isInProtectionList(mouseX, mouseY)) {
+            return false
+        }
+
+        refreshProtectionPlugins()
+        val row = (mouseY - protectionListTop) / PROTECTION_ROW_HEIGHT
+        val index = protectionScroll + row
+        if (index !in protectionPlugins.indices) {
+            return true
+        }
+
+        val plugin = protectionPlugins[index]
+        val onX = protectionListLeft + PROTECTION_LIST_WIDTH - 62
+        val offX = protectionListLeft + PROTECTION_LIST_WIDTH - 31
+        val toggleY = protectionListTop + row * PROTECTION_ROW_HEIGHT + 2
+
+        if (mouseY >= toggleY && mouseY < toggleY + PROTECTION_TOGGLE_HEIGHT) {
+            if (mouseX >= onX && mouseX < onX + PROTECTION_TOGGLE_WIDTH) {
+                setProtectionPluginState(plugin.id, true)
+                return true
+            }
+            if (mouseX >= offX && mouseX < offX + PROTECTION_TOGGLE_WIDTH) {
+                setProtectionPluginState(plugin.id, false)
+                return true
+            }
+        }
+        return true
+    }
+
+    private fun setProtectionPluginState(id: String, enabled: Boolean) {
+        if (gui.panelTrain.isProtectionPluginEnabled(id) == enabled) {
+            return
+        }
+        gui.playPanelClickSound()
+        gui.sendProtectionPluginState(id, enabled)
+    }
+
+    override fun handleMouseWheel(delta: Int): Boolean {
+        if (!isMouseInProtectionList()) {
+            return false
+        }
+        scrollProtectionPlugins(if (delta > 0) -1 else 1)
+        return true
+    }
+
+    override fun drawScreen(mouseX: Int, mouseY: Int, partialTicks: Float) {
+        refreshProtectionPlugins()
+        val x = protectionListLeft
+        val y = protectionListTop
+
+        gui.panelFontRenderer.drawString("Train Protection", x, gui.panelTop + 6, 4210752)
+        gui.drawPanelRect(
+            x - 1,
+            y - 1,
+            x + PROTECTION_LIST_WIDTH + 1,
+            y + PROTECTION_LIST_HEIGHT + 1,
+            0xFF555555.toInt()
+        )
+        gui.drawPanelRect(x, y, x + PROTECTION_LIST_WIDTH, y + PROTECTION_LIST_HEIGHT, 0xFFE8E8E8.toInt())
+
+        GL11.glEnable(GL11.GL_SCISSOR_TEST)
+        gui.enableGuiScissor(x, y, PROTECTION_LIST_WIDTH, PROTECTION_LIST_HEIGHT)
+        for (row in 0 until protectionVisibleRows) {
+            val index = protectionScroll + row
+            if (index >= protectionPlugins.size) {
+                break
+            }
+
+            val plugin = protectionPlugins[index]
+            val rowY = y + row * PROTECTION_ROW_HEIGHT
+            val enabled = gui.panelTrain.isProtectionPluginEnabled(plugin.id)
+            val hovered =
+                mouseX >= x && mouseX < x + PROTECTION_LIST_WIDTH && mouseY >= rowY && mouseY < rowY + PROTECTION_ROW_HEIGHT
+            gui.drawPanelRect(
+                x,
+                rowY,
+                x + PROTECTION_LIST_WIDTH,
+                rowY + PROTECTION_ROW_HEIGHT - 1,
+                if (hovered) 0xFFE0E7F0.toInt() else 0xFFF4F4F4.toInt()
+            )
+            drawProtectionPluginName(plugin.displayName, x + 4, rowY + 5, PROTECTION_LIST_WIDTH - 70)
+            drawProtectionToggle(x + PROTECTION_LIST_WIDTH - 62, rowY + 2, "ON", enabled)
+            drawProtectionToggle(x + PROTECTION_LIST_WIDTH - 31, rowY + 2, "OFF", !enabled)
+        }
+
+        if (protectionPlugins.isEmpty()) {
+            gui.panelFontRenderer.drawString("No plugins", x + 4, y + 5, 0x666666)
+        }
+
+        GL11.glDisable(GL11.GL_SCISSOR_TEST)
+
+        if (protectionMaxScroll > 0) {
+            val barX = x + PROTECTION_LIST_WIDTH - 4
+            val barHeight = max(12, PROTECTION_LIST_HEIGHT * protectionVisibleRows / protectionPlugins.size)
+            val barTravel = PROTECTION_LIST_HEIGHT - barHeight
+            val barY = y + barTravel * protectionScroll / protectionMaxScroll
+            gui.drawPanelRect(barX, y, barX + 3, y + PROTECTION_LIST_HEIGHT, 0xFFB8B8B8.toInt())
+            gui.drawPanelRect(barX, barY, barX + 3, barY + barHeight, 0xFF666666.toInt())
+        }
+    }
+
+    private fun refreshProtectionPlugins() {
+        protectionPlugins = TrainProtectionPluginManager.getPluginInfos()
+        protectionScroll = max(0, min(protectionScroll, protectionMaxScroll))
+    }
+
+    private val protectionVisibleRows: Int
+        get() = PROTECTION_LIST_HEIGHT / PROTECTION_ROW_HEIGHT
+
+    private val protectionMaxScroll: Int
+        get() = max(0, protectionPlugins.size - protectionVisibleRows)
+
+    private val protectionListLeft: Int
+        get() = gui.panelLeft + PROTECTION_LIST_X
+
+    private val protectionListTop: Int
+        get() = gui.panelTop + PROTECTION_LIST_Y
+
+    private fun isMouseInProtectionList(): Boolean {
+        val mouseX = Mouse.getEventX() * gui.screenWidth / gui.panelMinecraft.displayWidth
+        val mouseY = gui.screenHeight - Mouse.getEventY() * gui.screenHeight / gui.panelMinecraft.displayHeight - 1
+        return isInProtectionList(mouseX, mouseY)
+    }
+
+    private fun isInProtectionList(mouseX: Int, mouseY: Int): Boolean {
+        val x = protectionListLeft
+        val y = protectionListTop
+        return mouseX >= x && mouseX < x + PROTECTION_LIST_WIDTH && mouseY >= y && mouseY < y + PROTECTION_LIST_HEIGHT
+    }
+
+    private fun scrollProtectionPlugins(amount: Int) {
+        refreshProtectionPlugins()
+        protectionScroll = max(0, min(protectionScroll + amount, protectionMaxScroll))
+    }
+
+    private fun drawProtectionPluginName(name: String, x: Int, y: Int, width: Int) {
+        val text = gui.panelFontRenderer.trimStringToWidth(name, width)
+        gui.panelFontRenderer.drawString(text, x, y, 0x303030)
+    }
+
+    private fun drawProtectionToggle(x: Int, y: Int, label: String, selected: Boolean) {
+        val color = if (selected) 0xFF4E8F5A.toInt() else 0xFF9A9A9A.toInt()
+        gui.drawPanelRect(x, y, x + PROTECTION_TOGGLE_WIDTH, y + PROTECTION_TOGGLE_HEIGHT, color)
+        gui.drawPanelCenteredString(label, x + PROTECTION_TOGGLE_WIDTH / 2, y + 3, 0xFFFFFF)
+    }
+
+    companion object {
+        private const val PROTECTION_ROW_HEIGHT = 18
+        private const val PROTECTION_LIST_X = 8
+        private const val PROTECTION_LIST_Y = 18
+        private const val PROTECTION_LIST_WIDTH = 160
+        private const val PROTECTION_LIST_HEIGHT = 108
+        private const val PROTECTION_TOGGLE_WIDTH = 28
+        private const val PROTECTION_TOGGLE_HEIGHT = 14
+    }
+}

--- a/src/main/java/jp/ngt/rtm/gui/TrainControlPanelProtectionPage.kt
+++ b/src/main/java/jp/ngt/rtm/gui/TrainControlPanelProtectionPage.kt
@@ -119,7 +119,7 @@ class TrainControlPanelProtectionPage(gui: GuiTrainControlPanel) : TrainControlP
     }
 
     private fun refreshProtectionPlugins() {
-        protectionPlugins = TrainProtectionPluginManager.getPluginInfos()
+        protectionPlugins = TrainProtectionPluginManager.getPluginInfos().filterNot { it.hidden }
         protectionScroll = max(0, min(protectionScroll, protectionMaxScroll))
     }
 

--- a/src/main/java/jp/ngt/rtm/gui/TrainControlPanelSettingPage.kt
+++ b/src/main/java/jp/ngt/rtm/gui/TrainControlPanelSettingPage.kt
@@ -1,0 +1,236 @@
+package jp.ngt.rtm.gui
+
+import jp.kaiz.kaizpatch.gui.GuiButtonWithScrollingListBox
+import jp.ngt.rtm.entity.train.util.TrainState
+import jp.ngt.rtm.entity.train.util.TrainState.TrainStateType
+import jp.ngt.rtm.modelpack.cfg.TrainConfig
+import jp.ngt.rtm.modelpack.modelset.ModelSetVehicleBaseClient
+import net.minecraft.client.gui.GuiButton
+import net.minecraft.client.resources.I18n
+
+class TrainControlPanelSettingPage(gui: GuiTrainControlPanel) : TrainControlPanelPage(gui) {
+    private var buttonChunkLoader: GuiButton? = null
+    private val buttonDirection = arrayOfNulls<GuiButton>(3)
+
+    override fun init() {
+        val train = gui.panelTrain
+        val modelset = gui.panelModelSet
+
+        val interiorLight = TrainStateType.State_InteriorLight
+        gui.addPanelButton(
+            GuiButton(
+                124,
+                gui.panelLeft + 4,
+                gui.panelTop + 4,
+                82,
+                20,
+                gui.getFormattedText(interiorLight.id, train.getTrainStateData(interiorLight.id))
+            )
+        )
+        gui.addPanelButton(
+            GuiButton(
+                125,
+                gui.panelLeft + 90,
+                gui.panelTop + 4,
+                82,
+                20,
+                gui.getFormattedText(5, train.getTrainStateData(5))
+            )
+        )
+        gui.addPanelButton(
+            GuiButton(
+                126,
+                gui.panelLeft + 4,
+                gui.panelTop + 28,
+                82,
+                20,
+                gui.getFormattedText(6, train.getTrainStateData(6))
+            )
+        )
+
+        val direction = train.getTrainStateData(TrainStateType.State_Direction.id).toInt()
+        for (i in 0 until 3) {
+            val button = GuiButton(
+                140 + i,
+                gui.panelLeft + 91 + 27 * i,
+                gui.panelTop + 28,
+                27,
+                20,
+                gui.getFormattedText(TrainStateType.State_Direction.id, i.toByte())
+            )
+            button.enabled = i != direction
+            buttonDirection[i] = button
+            gui.addPanelButton(button)
+        }
+
+        buttonChunkLoader = GuiButton(
+            127,
+            gui.panelLeft + 28,
+            gui.panelTop + 52,
+            120,
+            20,
+            gui.getFormattedText(7, train.getTrainStateData(7))
+        )
+        gui.addPanelButton(buttonChunkLoader)
+        gui.addPanelButton(GuiButton(110, gui.panelLeft + 4, gui.panelTop + 52, 20, 20, "<"))
+        gui.addPanelButton(GuiButton(111, gui.panelLeft + 152, gui.panelTop + 52, 20, 20, ">"))
+
+        if ((modelset as ModelSetVehicleBaseClient<TrainConfig>).rollsignTexture != null) {
+            gui.addPanelButton(
+                GuiButtonWithScrollingListBox(
+                    128,
+                    gui.panelLeft + 28,
+                    gui.panelTop + 76,
+                    120,
+                    20,
+                    { train.getTrainStateData(8).toInt() },
+                    modelset.config.rollsignNames.asList(),
+                    I18n.format("state.destination") + " %s"
+                ) {
+                    gui.sendTrainState(8, toByte())
+                }
+            )
+            gui.addPanelButton(GuiButton(112, gui.panelLeft + 4, gui.panelTop + 76, 20, 20, "<"))
+            gui.addPanelButton(GuiButton(113, gui.panelLeft + 152, gui.panelTop + 76, 20, 20, ">"))
+        }
+
+        if (modelset.config.sound_Announcement != null) {
+            gui.addPanelButton(
+                GuiButtonWithScrollingListBox(
+                    129,
+                    gui.panelLeft + 28,
+                    gui.panelTop + 100,
+                    120,
+                    20,
+                    { train.getTrainStateData(9).toInt() },
+                    modelset.config.sound_Announcement.map { it[0] },
+                    I18n.format("state.announcement") + " %s"
+                ) {
+                    gui.sendTrainState(9, toByte())
+                }
+            )
+            gui.addPanelButton(GuiButton(114, gui.panelLeft + 4, gui.panelTop + 100, 20, 20, "<"))
+            gui.addPanelButton(GuiButton(115, gui.panelLeft + 152, gui.panelTop + 100, 20, 20, ">"))
+        }
+    }
+
+    override fun actionPerformed(button: GuiButton): Boolean {
+        if ((button.id !in 110..115) && (button.id !in 124..129) && (button.id !in 140..142)) {
+            return false
+        }
+        if (button.id == 128 || button.id == 129) {
+            return true
+        }
+
+        val train = gui.panelTrain
+        val modelset = gui.panelModelSet
+        val stateId: Int
+        var data: Int
+
+        when (button.id) {
+            110 -> {
+                stateId = 7
+                data = train.getTrainStateData(stateId) - 1
+            }
+
+            111 -> {
+                stateId = 7
+                data = train.getTrainStateData(stateId) + 1
+            }
+
+            112 -> {
+                stateId = 8
+                data = train.getTrainStateData(stateId) - 1
+                if (data < 0) {
+                    data = modelset.config.rollsignNames.size - 1
+                }
+            }
+
+            113 -> {
+                stateId = 8
+                data = train.getTrainStateData(stateId) + 1
+                if (data >= modelset.config.rollsignNames.size) {
+                    data = 0
+                }
+            }
+
+            114 -> {
+                val announce = modelset.config.sound_Announcement
+                stateId = 9
+                data = train.getTrainStateData(stateId) - 1
+                if (announce != null && data < 0) {
+                    data = announce.size - 1
+                }
+            }
+
+            115 -> {
+                val announce = modelset.config.sound_Announcement
+                stateId = 9
+                data = train.getTrainStateData(stateId) + 1
+                if (announce != null && data >= announce.size) {
+                    data = 0
+                }
+            }
+
+            in 124..129 -> {
+                stateId = if (button.id == 124) TrainStateType.State_InteriorLight.id else button.id - 120
+                data = train.getTrainStateData(stateId) + 1
+            }
+
+            else -> {
+                stateId = TrainStateType.State_Direction.id
+                data = button.id - 140
+                for (i in 0 until 3) {
+                    buttonDirection[i]?.enabled = i != data
+                }
+            }
+        }
+
+        val stateType = TrainState.getStateType(stateId)
+        val wrappedData = if (data < stateType.min) stateType.max else if (data > stateType.max) stateType.min else data
+        gui.sendTrainState(stateId, wrappedData.toByte())
+
+        if (button.id == 110 || button.id == 111) {
+            buttonChunkLoader?.displayString = gui.getFormattedText(stateId, wrappedData.toByte())
+        } else if (button.id != 112 && button.id != 113 && button.id != 114 && button.id != 115) {
+            button.displayString = gui.getFormattedText(stateId, wrappedData.toByte())
+        }
+        return true
+    }
+
+    override fun handleMouseWheel(delta: Int): Boolean {
+        val step = if (delta > 0) -1 else 1
+        val button = gui.panelButtons.firstOrNull { it.func_146115_a() && it.id in 124..129 } ?: return false
+
+        var stateId = button.id - 120
+        if (button.id == 124) {
+            stateId = TrainStateType.State_InteriorLight.id
+        }
+        val prevData = gui.panelTrain.getTrainStateData(stateId)
+        var data = prevData + step
+
+        val stateType = TrainState.getStateType(stateId)
+        val min: Int
+        val max: Int
+        if (stateType == TrainStateType.State_Destination) {
+            val rollSignNames = gui.panelModelSet.config.rollsignNames
+            min = 0
+            max = if (rollSignNames != null) rollSignNames.size - 1 else 0
+        } else if (stateType == TrainStateType.State_Announcement) {
+            val announce = gui.panelModelSet.config.sound_Announcement
+            min = 0
+            max = if (announce != null) announce.size - 1 else 0
+        } else {
+            min = stateType.min.toInt()
+            max = stateType.max.toInt()
+        }
+
+        data = if (data < min) max else if (data > max) min else data
+        if (prevData.toInt() != data) {
+            gui.sendTrainState(stateId, data.toByte())
+            button.func_146113_a(gui.panelMinecraft.soundHandler)
+            button.displayString = gui.getFormattedText(stateId, data.toByte())
+        }
+        return true
+    }
+}

--- a/src/main/java/jp/ngt/rtm/item/ItemInstalledObject.java
+++ b/src/main/java/jp/ngt/rtm/item/ItemInstalledObject.java
@@ -8,10 +8,7 @@ import jp.ngt.rtm.block.OrnamentType;
 import jp.ngt.rtm.block.tileentity.*;
 import jp.ngt.rtm.electric.Connection.ConnectionType;
 import jp.ngt.rtm.electric.*;
-import jp.ngt.rtm.entity.EntityATC;
-import jp.ngt.rtm.entity.EntityBumpingPost;
-import jp.ngt.rtm.entity.EntityInstalledObject;
-import jp.ngt.rtm.entity.EntityTrainDetector;
+import jp.ngt.rtm.entity.*;
 import jp.ngt.rtm.modelpack.cfg.ConnectorConfig;
 import jp.ngt.rtm.modelpack.cfg.MachineConfig;
 import jp.ngt.rtm.modelpack.cfg.OrnamentConfig;
@@ -229,6 +226,10 @@ public class ItemInstalledObject extends ItemWithModel {
             if (par7 == 1 && this.setEntityOnRail(world, new EntityTrainDetector(world), par4, par5 - 1, par6, player, itemStack)) {
                 block = Blocks.stone;
             }
+        } else if (type == IstlObjType.TRANSPONDER) {
+            if (par7 == 1 && this.setEntityOnRail(world, new EntityTransponder(world), par4, par5 - 1, par6, player, itemStack)) {
+                block = Blocks.stone;
+            }
         } else if (type == IstlObjType.INSULATOR) {
             world.setBlock(par4, par5, par6, RTMBlock.insulator, par7, 2);
             TileEntityInsulator tile = (TileEntityInsulator) world.getTileEntity(par4, par5, par6);
@@ -350,7 +351,7 @@ public class ItemInstalledObject extends ItemWithModel {
         this.icons[IstlObjType.STAIR.id] = register.registerIcon("rtm:stair");
         this.icons[IstlObjType.SCAFFOLD.id] = register.registerIcon("rtm:scaffold");
         this.icons[IstlObjType.SPEAKER.id] = register.registerIcon("rtm:speaker");
-        this.icons[24] = missing;
+        this.icons[IstlObjType.TRANSPONDER.id] = register.registerIcon("rtm:itemATC");
     }
 
     @Override
@@ -401,7 +402,7 @@ public class ItemInstalledObject extends ItemWithModel {
         STAIR(21, OrnamentConfig.TYPE, OrnamentType.Stair.toString(), "ScaffoldStair01"),
         SCAFFOLD(22, OrnamentConfig.TYPE, OrnamentType.Scaffold.toString(), "Scaffold01"),
         SPEAKER(23, MachineConfig.TYPE, MachineType.Speaker.toString(), "Speaker01"),
-        //		MECHANISM(24, "", "", ""),
+        TRANSPONDER(24, MachineConfig.TYPE, MachineType.Transponder.toString(), "Transponder_01"),
         NONE(-1, "", "", "");
 
         public final byte id;

--- a/src/main/java/jp/ngt/rtm/modelpack/ModelPackLoadThread.java
+++ b/src/main/java/jp/ngt/rtm/modelpack/ModelPackLoadThread.java
@@ -135,12 +135,25 @@ public final class ModelPackLoadThread extends Thread implements IProgressWatche
 
     private void loadModelFromConfig() {
         this.setValue(0, 1, "Loading Train Models");
-        Pattern pattern = Pattern.compile("Model.*\\.json");
-        List<File> fileList = NGTFileLoader.findFile(file -> pattern.matcher(file.getName()).matches());
+        Pattern modelPattern = Pattern.compile("Model.*\\.json");
+        List<File> fileList = NGTFileLoader.findFile(file -> modelPattern.matcher(file.getName()).matches());
+        List<File> protectionPluginFiles = NGTFileLoader.findFile(file -> TrainProtectionPluginConfig.CONFIG_FILE_PATTERN.matcher(file.getName()).matches());
 
         List<File> signBoards = TextureManager.INSTANCE.loadTextures(this);
         List<File> railRoadSigns = TextureManager.INSTANCE.loadRailRoadSigns(this);
         List<File> flags = TextureManager.INSTANCE.loadFlags(this);
+
+        this.setValue(0, 2, "Loading Train Protection Plugins");
+        protectionPluginFiles.stream().filter(Objects::nonNull).forEach(file -> {
+            try {
+                String jsonText = NGTJson.readFromJson(file);
+
+                TrainProtectionPluginConfig config = (TrainProtectionPluginConfig) NGTJson.getObjectFromJson(jsonText, TrainProtectionPluginConfig.class);
+                TrainProtectionPluginManager.register(config);
+            } catch (Throwable e) {
+                throw new ModelPackException("Can't load train protection plugin", file.getAbsolutePath(), e);
+            }
+        });
 
         this.setValue(0, 4, "Registering All Models");
         this.setMaxValue(1, fileList.size(), "");

--- a/src/main/java/jp/ngt/rtm/modelpack/ModelPackLoadThread.java
+++ b/src/main/java/jp/ngt/rtm/modelpack/ModelPackLoadThread.java
@@ -7,6 +7,8 @@ import jp.ngt.ngtlib.io.NGTJson;
 import jp.ngt.ngtlib.io.NGTLog;
 import jp.ngt.rtm.RTMConfig;
 import jp.ngt.rtm.RTMCore;
+import jp.ngt.rtm.entity.train.protection.TrainProtectionPluginConfig;
+import jp.ngt.rtm.entity.train.protection.TrainProtectionPluginManager;
 import jp.ngt.rtm.modelpack.texture.TextureManager;
 import jp.ngt.rtm.network.PacketModelPack;
 import jp.ngt.rtm.network.PacketNotice;

--- a/src/main/java/jp/ngt/rtm/modelpack/ScriptExecuter.java
+++ b/src/main/java/jp/ngt/rtm/modelpack/ScriptExecuter.java
@@ -27,9 +27,13 @@ public class ScriptExecuter implements ICommandSender {
     }
 
     public void execScript(IModelSelector selector) {
-        this.caller = selector;
-        this.callMethod(selector, "onUpdate", selector, this);
+        this.execScript(selector, "onUpdate", selector, this);
         ++this.count;
+    }
+
+    public Object execScript(IModelSelector selector, String eventName, Object... args) {
+        this.caller = selector;
+        return this.callMethod(selector, eventName, args);
     }
 
     public void execCommand(String command) {

--- a/src/main/java/jp/ngt/rtm/network/PacketNoticeHandlerServer.java
+++ b/src/main/java/jp/ngt/rtm/network/PacketNoticeHandlerServer.java
@@ -46,6 +46,15 @@ public class PacketNoticeHandlerServer implements IMessageHandler<PacketNotice, 
                         ((ContainerTrainControlPanel) container).setCurrentTab(tabIndex);
                     }
                 }
+            } else if (message.notice.startsWith("setTrainProtectionPlugin")) {
+                String[] sa = message.notice.split(",");
+                Entity entity = message.getEntity(world);
+                if (sa.length >= 3 && entity instanceof EntityTrainBase && player.openContainer instanceof ContainerTrainControlPanel) {
+                    ContainerTrainControlPanel container = (ContainerTrainControlPanel) player.openContainer;
+                    if (container.train == entity) {
+                        ((EntityTrainBase) entity).setProtectionPluginEnabled(sa[1], Boolean.parseBoolean(sa[2]));
+                    }
+                }
             } else if (message.notice.startsWith("workbench")) {
                 String[] sa = message.notice.split(",");
                 String name = sa[1];

--- a/src/main/java/jp/ngt/rtm/network/PacketTrainProtectionPluginList.kt
+++ b/src/main/java/jp/ngt/rtm/network/PacketTrainProtectionPluginList.kt
@@ -21,6 +21,7 @@ class PacketTrainProtectionPluginList() : IMessage, IMessageHandler<PacketTrainP
             ByteBufUtils.writeUTF8String(buffer, plugin.id)
             ByteBufUtils.writeUTF8String(buffer, plugin.displayName)
             buffer.writeBoolean(plugin.defaultEnabled)
+            buffer.writeBoolean(plugin.hidden)
         }
     }
 
@@ -32,6 +33,7 @@ class PacketTrainProtectionPluginList() : IMessage, IMessageHandler<PacketTrainP
                 TrainProtectionPluginInfo(
                     ByteBufUtils.readUTF8String(buffer),
                     ByteBufUtils.readUTF8String(buffer),
+                    buffer.readBoolean(),
                     buffer.readBoolean()
                 )
             )

--- a/src/main/java/jp/ngt/rtm/network/PacketTrainProtectionPluginList.kt
+++ b/src/main/java/jp/ngt/rtm/network/PacketTrainProtectionPluginList.kt
@@ -1,0 +1,46 @@
+package jp.ngt.rtm.network
+
+import cpw.mods.fml.common.network.ByteBufUtils
+import cpw.mods.fml.common.network.simpleimpl.IMessage
+import cpw.mods.fml.common.network.simpleimpl.IMessageHandler
+import cpw.mods.fml.common.network.simpleimpl.MessageContext
+import io.netty.buffer.ByteBuf
+import jp.ngt.rtm.entity.train.protection.TrainProtectionPluginInfo
+import jp.ngt.rtm.entity.train.protection.TrainProtectionPluginManager
+
+class PacketTrainProtectionPluginList() : IMessage, IMessageHandler<PacketTrainProtectionPluginList, IMessage> {
+    private var plugins: List<TrainProtectionPluginInfo> = emptyList()
+
+    constructor(plugins: List<TrainProtectionPluginInfo>) : this() {
+        this.plugins = plugins
+    }
+
+    override fun toBytes(buffer: ByteBuf) {
+        buffer.writeInt(plugins.size)
+        for (plugin in plugins) {
+            ByteBufUtils.writeUTF8String(buffer, plugin.id)
+            ByteBufUtils.writeUTF8String(buffer, plugin.displayName)
+            buffer.writeBoolean(plugin.defaultEnabled)
+        }
+    }
+
+    override fun fromBytes(buffer: ByteBuf) {
+        val size = buffer.readInt()
+        val entries = ArrayList<TrainProtectionPluginInfo>(size)
+        for (i in 0 until size) {
+            entries.add(
+                TrainProtectionPluginInfo(
+                    ByteBufUtils.readUTF8String(buffer),
+                    ByteBufUtils.readUTF8String(buffer),
+                    buffer.readBoolean()
+                )
+            )
+        }
+        plugins = entries
+    }
+
+    override fun onMessage(message: PacketTrainProtectionPluginList, ctx: MessageContext): IMessage? {
+        TrainProtectionPluginManager.setSyncedPluginInfos(message.plugins)
+        return null
+    }
+}

--- a/src/main/java/jp/ngt/rtm/network/PacketTrainProtectionPluginState.kt
+++ b/src/main/java/jp/ngt/rtm/network/PacketTrainProtectionPluginState.kt
@@ -1,0 +1,49 @@
+package jp.ngt.rtm.network
+
+import cpw.mods.fml.common.network.ByteBufUtils
+import cpw.mods.fml.common.network.simpleimpl.IMessage
+import cpw.mods.fml.common.network.simpleimpl.IMessageHandler
+import cpw.mods.fml.common.network.simpleimpl.MessageContext
+import io.netty.buffer.ByteBuf
+import jp.ngt.ngtlib.util.NGTUtil
+import jp.ngt.rtm.RTMCore
+import jp.ngt.rtm.entity.train.EntityTrainBase
+
+class PacketTrainProtectionPluginState() : IMessage, IMessageHandler<PacketTrainProtectionPluginState, IMessage> {
+    private var entityId = 0
+    private var pluginId = ""
+    private var enabled = false
+
+    constructor(train: EntityTrainBase, pluginId: String, enabled: Boolean) : this() {
+        this.entityId = train.entityId
+        this.pluginId = pluginId
+        this.enabled = enabled
+    }
+
+    override fun toBytes(buffer: ByteBuf) {
+        buffer.writeInt(entityId)
+        ByteBufUtils.writeUTF8String(buffer, pluginId)
+        buffer.writeBoolean(enabled)
+    }
+
+    override fun fromBytes(buffer: ByteBuf) {
+        entityId = buffer.readInt()
+        pluginId = ByteBufUtils.readUTF8String(buffer)
+        enabled = buffer.readBoolean()
+    }
+
+    override fun onMessage(message: PacketTrainProtectionPluginState, ctx: MessageContext): IMessage? {
+        val entity = NGTUtil.getClientWorld()?.getEntityByID(message.entityId)
+        if (entity is EntityTrainBase) {
+            entity.applyProtectionPluginState(message.pluginId, message.enabled)
+        }
+        return null
+    }
+
+    companion object {
+        @JvmStatic
+        fun sendToClient(train: EntityTrainBase, pluginId: String, enabled: Boolean) {
+            RTMCore.NETWORK_WRAPPER.sendToAll(PacketTrainProtectionPluginState(train, pluginId, enabled))
+        }
+    }
+}

--- a/src/main/java/jp/ngt/rtm/sound/SoundUpdaterTrain.java
+++ b/src/main/java/jp/ngt/rtm/sound/SoundUpdaterTrain.java
@@ -4,6 +4,7 @@ import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import jp.ngt.rtm.entity.train.EntityBogie;
 import jp.ngt.rtm.entity.train.EntityTrainBase;
+import jp.ngt.rtm.entity.train.protection.RtmDefaultTrainProtectionPlugin;
 import jp.ngt.rtm.entity.train.util.EnumNotch;
 import jp.ngt.rtm.entity.train.util.Formation;
 import jp.ngt.rtm.modelpack.cfg.TrainConfig;
@@ -29,22 +30,22 @@ public class SoundUpdaterTrain extends SoundUpdaterVehicle {
 
     @Override
     public void update() {
+        boolean defaultProtectionEnabled = this.theTrain.isProtectionPluginEnabled(RtmDefaultTrainProtectionPlugin.ID);
+        if (!defaultProtectionEnabled) {
+            this.stopATSSounds();
+        }
+
         EntityBogie bogie = this.theTrain.getBogie(this.theTrain.getTrainDirection());
         if (bogie == null) {
             return;
         }
 
         int signal = this.theTrain.getSignal();
-        if (this.theTrain.isControlCar() && Math.abs(this.theTrain.getSpeed()) > 0.0F) {
+        if (defaultProtectionEnabled && this.theTrain.isControlCar() && Math.abs(this.theTrain.getSpeed()) > 0.0F) {
             switch (signal) {
                 case 1:
                     if (this.currentSignal != 1) {
-                        if (this.atsSound[0] != null) {
-                            this.atsSound[0].stop();
-                        }
-                        if (this.atsSound[1] != null) {
-                            this.atsSound[1].stop();
-                        }
+                        this.stopATSSounds();
 
                         ModelSetVehicleBaseClient<TrainConfig> modelSet = (ModelSetVehicleBaseClient<TrainConfig>) this.theTrain.getModelSet();
 
@@ -60,6 +61,7 @@ public class SoundUpdaterTrain extends SoundUpdaterVehicle {
                     if (this.currentSignal != -1) {
                         if (this.atsSound[1] != null) {
                             this.atsSound[1].stop();
+                            this.atsSound[1] = null;
                         }
                         this.currentSignal = -1;
                     }
@@ -67,17 +69,23 @@ public class SoundUpdaterTrain extends SoundUpdaterVehicle {
             }
         } else {
             if (signal != -1 && this.currentSignal != 0) {
-                if (this.atsSound[0] != null) {
-                    this.atsSound[0].stop();
-                }
-                if (this.atsSound[1] != null) {
-                    this.atsSound[1].stop();
-                }
-                this.currentSignal = 0;
+                this.stopATSSounds();
             }
         }
 
         super.update();
+    }
+
+    private void stopATSSounds() {
+        if (this.atsSound[0] != null) {
+            this.atsSound[0].stop();
+            this.atsSound[0] = null;
+        }
+        if (this.atsSound[1] != null) {
+            this.atsSound[1].stop();
+            this.atsSound[1] = null;
+        }
+        this.currentSignal = 0;
     }
 
     @Override

--- a/src/main/resources/assets/minecraft/models/json/ModelMachine_Transponder_01.json
+++ b/src/main/resources/assets/minecraft/models/json/ModelMachine_Transponder_01.json
@@ -1,0 +1,66 @@
+{
+    "name": "Transponder_01",
+    "model": {
+        "modelFile": "ATC01.mqo",
+        "textures": [
+            [
+                "default",
+                "textures/machine/atc.png",
+                ""
+            ]
+        ]
+    },
+    "buttonTexture": "textures/machine/button_ATC_01.png",
+    "machineType": "Transponder",
+    "serverScriptPath": "scripts/TransponderSignal.js",
+    "followRailAngle": true,
+    "smoothing": false,
+    "doCulling": true,
+    "accuracy": "LOW",
+    "defaultValues": [
+        {
+            "type": "Int",
+            "key": "signalLevel",
+            "value": "1",
+            "minmax": [
+                -1,
+                127
+            ]
+        },
+        {
+            "type": "Boolean",
+            "key": "frontCarOnly",
+            "value": "true"
+        },
+        {
+            "type": "Boolean",
+            "key": "facingDirectionOnly",
+            "value": "false"
+        }
+    ],
+    "customForm": {
+        "title": "Transponder",
+        "columns": 1,
+        "fields": [
+            {
+                "key": "signalLevel",
+                "label": "Signal Level",
+                "row": 0,
+                "column": 0
+            },
+            {
+                "key": "frontCarOnly",
+                "label": "Front Car Only",
+                "row": 1,
+                "column": 0
+            },
+            {
+                "key": "facingDirectionOnly",
+                "label": "Facing Direction Only",
+                "row": 2,
+                "column": 0
+            }
+        ]
+    },
+    "tags": "Transponder"
+}

--- a/src/main/resources/assets/minecraft/models/json/ModelMachine_Transponder_Debug.json
+++ b/src/main/resources/assets/minecraft/models/json/ModelMachine_Transponder_Debug.json
@@ -1,0 +1,269 @@
+{
+    "name": "Transponder_Debug",
+    "model": {
+        "modelFile": "ATC01.mqo",
+        "textures": [
+            [
+                "default",
+                "textures/machine/atc.png",
+                ""
+            ]
+        ]
+    },
+    "buttonTexture": "textures/machine/button_ATC_01.png",
+    "machineType": "Transponder",
+    "serverScriptPath": "scripts/TransponderSignal.js",
+    "followRailAngle": true,
+    "smoothing": false,
+    "doCulling": true,
+    "accuracy": "LOW",
+    "defaultValues": [
+        {
+            "type": "String",
+            "key": "textValue",
+            "value": "debug-value",
+            "pattern": [
+                "debug-",
+                "",
+                ""
+            ]
+        },
+        {
+            "type": "String",
+            "key": "mode",
+            "value": "alpha",
+            "suggestions": [
+                "alpha",
+                "beta",
+                "gamma"
+            ]
+        },
+        {
+            "type": "Int",
+            "key": "signalLevel",
+            "value": "42",
+            "minmax": [
+                -1,
+                127
+            ]
+        },
+        {
+            "type": "Double",
+            "key": "doubleValue",
+            "value": "0.5",
+            "minmax": [
+                -10.0,
+                10.0
+            ]
+        },
+        {
+            "type": "Hex",
+            "key": "hexValue",
+            "value": "0x2a",
+            "minmax": [
+                0,
+                255
+            ]
+        },
+        {
+            "type": "Boolean",
+            "key": "frontCarOnly",
+            "value": "true"
+        },
+        {
+            "type": "Vec",
+            "key": "vectorValue",
+            "value": "1.0 2.0 3.0",
+            "minmax": [
+                -100.0,
+                100.0
+            ]
+        },
+        {
+            "type": "List",
+            "elementType": "String",
+            "key": "stringList",
+            "values": [
+                "alpha",
+                "beta"
+            ],
+            "minItems": 0,
+            "maxItems": 5,
+            "suggestions": [
+                "alpha",
+                "beta",
+                "gamma"
+            ]
+        },
+        {
+            "type": "List",
+            "elementType": "Int",
+            "key": "intList",
+            "values": [
+                "0",
+                "10"
+            ],
+            "minItems": 0,
+            "maxItems": 5,
+            "minmax": [
+                -100,
+                100
+            ]
+        },
+        {
+            "type": "List",
+            "elementType": "Double",
+            "key": "doubleList",
+            "values": [
+                "0.25",
+                "0.5"
+            ],
+            "minItems": 0,
+            "maxItems": 5,
+            "minmax": [
+                -1.0,
+                1.0
+            ]
+        },
+        {
+            "type": "List",
+            "elementType": "Hex",
+            "key": "hexList",
+            "values": [
+                "0x0",
+                "0xff"
+            ],
+            "minItems": 0,
+            "maxItems": 5,
+            "minmax": [
+                0,
+                255
+            ]
+        },
+        {
+            "type": "List",
+            "elementType": "Boolean",
+            "key": "booleanList",
+            "values": [
+                "true",
+                "false"
+            ],
+            "minItems": 0,
+            "maxItems": 5
+        },
+        {
+            "type": "List",
+            "elementType": "Vec",
+            "key": "vectorList",
+            "values": [
+                "0.0 0.0 0.0",
+                "1.0 2.0 3.0"
+            ],
+            "minItems": 0,
+            "maxItems": 5,
+            "minmax": [
+                -10.0,
+                10.0
+            ]
+        }
+    ],
+    "customForm": {
+        "title": "Transponder Debug",
+        "columns": 2,
+        "fields": [
+            {
+                "text": "Scalar fields あのイーハトーヴォのすきとおった風、夏でも底に冷たさをもつ青いそら、うつくしい森で飾られたモリーオ市、郊外のぎらぎらひかる草の波。",
+                "row": 0,
+                "column": 0,
+                "columnSpan": 2
+            },
+            {
+                "key": "textValue",
+                "label": "String / Pattern(debug-*)",
+                "row": 1,
+                "column": 0
+            },
+            {
+                "key": "mode",
+                "label": "String / Suggestions",
+                "row": 1,
+                "column": 1
+            },
+            {
+                "key": "signalLevel",
+                "label": "Int / Signal Level",
+                "row": 2,
+                "column": 0
+            },
+            {
+                "key": "doubleValue",
+                "label": "Double",
+                "row": 2,
+                "column": 1
+            },
+            {
+                "key": "hexValue",
+                "label": "Hex",
+                "row": 3,
+                "column": 0
+            },
+            {
+                "key": "frontCarOnly",
+                "label": "Boolean",
+                "row": 3,
+                "column": 1
+            },
+            {
+                "key": "vectorValue",
+                "label": "Vec",
+                "row": 4,
+                "column": 0,
+                "columnSpan": 2
+            },
+            {
+                "text": "List fields",
+                "row": 5,
+                "column": 0,
+                "columnSpan": 2
+            },
+            {
+                "key": "stringList",
+                "label": "List<String> / Suggestions",
+                "row": 6,
+                "column": 0
+            },
+            {
+                "key": "intList",
+                "label": "List<Int>",
+                "row": 6,
+                "column": 1
+            },
+            {
+                "key": "doubleList",
+                "label": "List<Double>",
+                "row": 7,
+                "column": 0
+            },
+            {
+                "key": "hexList",
+                "label": "List<Hex>",
+                "row": 7,
+                "column": 1
+            },
+            {
+                "key": "booleanList",
+                "label": "List<Boolean>",
+                "row": 8,
+                "column": 0
+            },
+            {
+                "key": "vectorList",
+                "label": "List<Vec>",
+                "row": 9,
+                "column": 0,
+                "columnSpan": 2
+            }
+        ]
+    },
+    "tags": "Transponder"
+}

--- a/src/main/resources/assets/minecraft/scripts/TransponderSignal.js
+++ b/src/main/resources/assets/minecraft/scripts/TransponderSignal.js
@@ -1,0 +1,18 @@
+function onUpdate(selector, executer) {
+
+}
+
+function onTrainPass(transponder, train, executer) {
+    var dataMap = transponder.getResourceState().getDataMap();
+    if (dataMap.getBoolean("facingDirectionOnly") && !transponder.isTrainFacingDirection(train)) {
+        return;
+    }
+
+    var formation = train.getFormation();
+    if (dataMap.getBoolean("frontCarOnly") && formation != null && !formation.isFrontCar(train)) {
+        return;
+    }
+
+    var signalLevel = dataMap.getInt("signalLevel");
+    train.setSignal2(signalLevel);
+}

--- a/src/main/resources/assets/rtm/lang/en_US.lang
+++ b/src/main/resources/assets/rtm/lang/en_US.lang
@@ -50,6 +50,7 @@ item.rtm:installedObject.20.name=Flag
 item.rtm:installedObject.21.name=Stair
 item.rtm:installedObject.22.name=Scaffold
 item.rtm:installedObject.23.name=Speaker
+item.rtm:installedObject.24.name=Transponder
 item.rtm:material.0.name=Shaft
 item.rtm:material.1.name=Wheel
 item.rtm:material.2.name=Diesel Engine

--- a/src/main/resources/assets/rtm/lang/ja_JP.lang
+++ b/src/main/resources/assets/rtm/lang/ja_JP.lang
@@ -50,6 +50,7 @@ item.rtm:installedObject.20.name=旗
 item.rtm:installedObject.21.name=階段
 item.rtm:installedObject.22.name=足場
 item.rtm:installedObject.23.name=スピーカー
+item.rtm:installedObject.24.name=地上子
 item.rtm:material.0.name=シャフト
 item.rtm:material.1.name=車輪
 item.rtm:material.2.name=ディーゼルエンジン


### PR DESCRIPTION
地上で完結する保安装置システムを実現する

- 内部ノッチ段数を追加
  - 現行の(物理)ノッチ段数と比較して制御される
   - ブレーキ: 絶対値が大きい段数を優先
   - 力行: 物理段数が1以上の場合は物理段数を優先 0の場合は内部段数を優先
     - ATO での使用を想定
- プラグイン式の列車保安装置を追加
  - js で
    - 起動時に登録する
      - config ファイルと js ファイルで 登録する（下記）
    - ゲーム内から登録する
      - 匿名関数（簡易方式） or 匿名関数を定義するオブジェクトリテラル（下記）
      - Nashorn の `Java#extend` が使えるかも
      - 基本的にはデバッグ用
  - Java で
    - `TrainProtectionPlugin` の継承クラス
  - 制御について車両のサーバースクリプトへ処理を依存しなくなる
  - 地上から `EntityTrainBase#enableProtectionPlugin(id: string)` または 車上の保安装置パネルでの有効化を想定
  - idに `:` を含むことはできません
- 非常ブレーキ段数を取得する関数を追加(EntityTrainBase#getEBNotch)
- 最大ノッチ段数を取得する関数を追加(EntityTrainBase#getMaxNotch)

<details>

<summary>configで登録 (TrainProtectionPlugin_.*\.json)</summary>

```jsonc
{
  "id": "hoge_plugin",
  "displayName": "Hoge総合PI",
  "scriptPath": "scripts/tpp_hogehoge.js",
  "defaultEnabled": false,
  "hidden": false
}
```
```js
function onRegister(train: EntityTrainBase) {
  // 登録時に呼ばれる
}

function onUnregister(train: EntityTrainBase) {
  // 解除時に呼ばれる

  // 例: お片付けをする
  ctx.dataMap.clear(DataMap.SYNC_FLAG)
}

function onServerTick(ctx: TrainProtectionContext) {
  if (ctx.speed > 20.0) {
    ctx.requestInternalNotch(-8);
  }
}

function onATSKeyDown(ctx: TrainProtectionContext, player: EntityPlayer) {
  ctx.dataMap.setBoolean("confirmed", true);
}
```

</details>


<details>

<summary>jsから登録</summary>

```js
// 簡易方式
importPackage(Packages.jp.ngt.rtm.entity.train.protection);

TrainProtectionPluginManager.registerProtectionPlugin("hoge_plugin", function(ctx: TrainProtectionContext) {
    // 0: 制御なし
    // 正数: (内部)P
    // 負数: (内部)B
    ctx.requestInternalNotch(-8);
}, false);
```

```js
// フル方式
importPackage(Packages.jp.ngt.rtm.entity.train.protection);

TrainProtectionPluginManager.registerProtectionPlugin("hoge_plugin", {
    onRegister: function(train: EntityTrainBase) {
        // 登録時に呼ばれる
    },

    onUnregister: function(train: EntityTrainBase) {
        // 解除時に呼ばれる

        // 例: お片付けをする
        ctx.dataMap.clear(DataMap.SYNC_FLAG)
    },

    onServerTick: function(ctx: TrainProtectionContext) {
        if (ctx.speed > 20.0) {
            ctx.requestInternalNotch(-8);
        }
    },

    onATSKeyDown: function(ctx: TrainProtectionContext, player: EntityPlayer) {
        ctx.dataMap.setBoolean("confirmed", true);
    }
}, false);
```

</details>

```js
// 例えば地上子で呼び出し
// 有効
train.setProtectionPluginEnabled("hoge_plugin", true)
```
- 現行のデフォルト保安装置（1で音が鳴るやつ）をプラグインのひとつに変更
  - 無効化が可能
- サーバースクリプト `getAcceleration`, `getDeceleration` 関数の引数を追加
  - 第三引数 `notch: number` を追加
    - `(train: EntityTrainBase, prevSpeed: number, notch: number)` になります
  - 内部ノッチ段数追加に伴い計算基準とするノッチ段数を提供
  - 後方互換のある変更ですが、保安装置等との共存が難しくなるので対応を推奨

実装方針メモ
- 音を扱えるようにする
  - 現行のデフォルト保安装置を一般化する
- Guiを扱えるようにする
- 必要減速度に基づくノッチ制御
  - 必要加速度も
- 制御段数（31段とかの）
  - 滑らかな制御のため
  - https://www.global.toshiba/jp/technology/infrastructure/ird/case/secret/social/detail-09.html
