### PR TITLE
feat: section rail

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,8 @@ minecraft {
     runDir = "eclipse"
 }
 
+def kotestVersion = '5.9.1'
+
 dependencies {
     // you may put jars on which you depend on in ./libs
     // or you may define them like so..
@@ -53,6 +55,12 @@ dependencies {
     embed "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     compileOnly 'org.jetbrains:annotations:26.1.0'
     embed 'org.sejda.imageio:webp-imageio:0.1.6'
+    testImplementation "io.kotest:kotest-runner-junit5:$kotestVersion"
+    testImplementation "io.kotest:kotest-assertions-core:$kotestVersion"
+}
+
+tasks.withType(Test).configureEach {
+    useJUnitPlatform()
 }
 
 processResources {

--- a/src/main/java/jp/kaiz/kaizpatch/rtm/rail/TileEntityLargeRailSectionCore.kt
+++ b/src/main/java/jp/kaiz/kaizpatch/rtm/rail/TileEntityLargeRailSectionCore.kt
@@ -1,0 +1,271 @@
+package jp.kaiz.kaizpatch.rtm.rail
+
+import jp.kaiz.kaizpatch.rtm.rail.util.RailMapSection
+import jp.ngt.rtm.rail.TileEntityLargeRailBase
+import jp.ngt.rtm.rail.TileEntityLargeRailCore
+import jp.ngt.rtm.rail.TileEntityLargeRailNormalCore
+import jp.ngt.rtm.rail.util.RailMapBasic
+import jp.ngt.rtm.rail.util.RailPosition
+import jp.ngt.rtm.rail.util.RailProperty
+import net.minecraft.nbt.NBTTagCompound
+import net.minecraft.nbt.NBTTagList
+import java.util.*
+
+/** チャンク単位に分割された通常レールの担当区間を保持する */
+class TileEntityLargeRailSectionCore : TileEntityLargeRailNormalCore() {
+    private var railGroupId: UUID? = null
+    private var logicalRailPositions: Array<RailPosition>? = null
+    private var sectionStartRatio = 0.0
+    private var sectionEndRatio = 1.0
+    private var railGroupCorePositions: Array<IntArray> = emptyArray()
+
+    fun configureRailSection(
+        groupId: UUID,
+        logicalPositions: Array<RailPosition>,
+        sectionPositions: Array<RailPosition>,
+        startRatio: Double,
+        endRatio: Double,
+        corePositions: List<IntArray>,
+    ) {
+        railGroupId = groupId
+        logicalRailPositions = copyRailPositions(logicalPositions)
+        railPositions = copyRailPositions(sectionPositions)
+        sectionStartRatio = startRatio
+        sectionEndRatio = endRatio
+        railGroupCorePositions = copyPositions(corePositions)
+        railmap = null
+    }
+
+    fun isRailSection(): Boolean = railGroupId != null && logicalRailPositions?.size == 2
+
+    fun getRailGroupId(): UUID? = railGroupId
+
+    override fun isSameLogicalRail(other: TileEntityLargeRailCore): Boolean {
+        if (this === other) return true
+        if (!isRailSection() || other !is TileEntityLargeRailSectionCore || !other.isRailSection()) return false
+        return railGroupId == other.railGroupId &&
+            containsCorePosition(other.xCoord, other.yCoord, other.zCoord) &&
+            other.containsCorePosition(xCoord, yCoord, zCoord)
+    }
+
+    override fun getLogicalRailPositions(): Array<RailPosition> {
+        val logical = logicalRailPositions
+        return if (isRailSection() && logical != null) copyRailPositions(logical) else super.getLogicalRailPositions()
+    }
+
+    fun getRailGroupCorePositions(): List<IntArray> = railGroupCorePositions.map(IntArray::clone)
+
+    protected override fun readRailData(nbt: NBTTagCompound) {
+        super.readRailData(nbt)
+        readSectionData(nbt)
+    }
+
+    protected override fun writeRailData(nbt: NBTTagCompound) {
+        super.writeRailData(nbt)
+        writeSectionData(nbt)
+    }
+
+    fun readSectionData(parent: NBTTagCompound) {
+        railGroupId = null
+        logicalRailPositions = null
+        sectionStartRatio = 0.0
+        sectionEndRatio = 1.0
+        railGroupCorePositions = emptyArray()
+        railmap = null
+        if (!parent.hasKey(SECTION_TAG)) return
+
+        val section = parent.getCompoundTag(SECTION_TAG)
+        if (!section.hasKey("GroupMost") || !section.hasKey("GroupLeast") ||
+            !section.hasKey("StartRatio") || !section.hasKey("EndRatio") ||
+            !section.hasKey("LogicalStartRP") || !section.hasKey("LogicalEndRP") ||
+            !section.hasKey("CorePositions")
+        ) {
+            return
+        }
+
+        railGroupId = UUID(section.getLong("GroupMost"), section.getLong("GroupLeast"))
+        logicalRailPositions = arrayOf(
+            RailPosition.readFromNBT(section.getCompoundTag("LogicalStartRP")),
+            RailPosition.readFromNBT(section.getCompoundTag("LogicalEndRP")),
+        )
+        sectionStartRatio = section.getDouble("StartRatio")
+        sectionEndRatio = section.getDouble("EndRatio")
+
+        val positions = section.getTagList("CorePositions", 10)
+        railGroupCorePositions = Array(positions.tagCount()) { index ->
+            val pos = positions.getCompoundTagAt(index)
+            intArrayOf(pos.getInteger("X"), pos.getInteger("Y"), pos.getInteger("Z"))
+        }
+        railmap = null
+    }
+
+    fun writeSectionData(parent: NBTTagCompound) {
+        val groupId = railGroupId ?: return
+        val logical = logicalRailPositions ?: return
+        if (!isRailSection()) return
+
+        val section = NBTTagCompound()
+        section.setLong("GroupMost", groupId.mostSignificantBits)
+        section.setLong("GroupLeast", groupId.leastSignificantBits)
+        section.setDouble("StartRatio", sectionStartRatio)
+        section.setDouble("EndRatio", sectionEndRatio)
+        section.setTag("LogicalStartRP", logical[0].writeToNBT())
+        section.setTag("LogicalEndRP", logical[1].writeToNBT())
+        val positions = NBTTagList()
+        railGroupCorePositions.forEach { corePos ->
+            val pos = NBTTagCompound()
+            pos.setInteger("X", corePos[0])
+            pos.setInteger("Y", corePos[1])
+            pos.setInteger("Z", corePos[2])
+            positions.appendTag(pos)
+        }
+        section.setTag("CorePositions", positions)
+        parent.setTag(SECTION_TAG, section)
+    }
+
+    override fun createRailMap() {
+        if (!isLoaded) return
+        val logical = logicalRailPositions
+        if (!isRailSection() || logical == null) {
+            super.createRailMap()
+            return
+        }
+        val copied = copyRailPositions(logical)
+        val source = RailMapBasic(copied[0], copied[1], fixRTMRailMapVersion)
+        railmap = RailMapSection(source, railPositions[0], railPositions[1], sectionStartRatio, sectionEndRatio)
+    }
+
+    override fun replaceRail(state: RailProperty) {
+        if (!isRailSection() || worldObj == null) {
+            super.replaceRail(state)
+            return
+        }
+        groupCores.forEach { it.replaceRailLocal(state) }
+    }
+
+    private fun replaceRailLocal(state: RailProperty) = super.replaceRail(state)
+
+    override fun addSubRail(state: RailProperty) {
+        if (!isRailSection() || worldObj == null) {
+            super.addSubRail(state)
+            return
+        }
+        groupCores.forEach { it.addSubRailLocal(state) }
+    }
+
+    private fun addSubRailLocal(state: RailProperty) = super.addSubRail(state)
+
+    override fun setSignal(signal: Int) {
+        if (!isRailSection() || worldObj == null) {
+            super.setSignal(signal)
+            return
+        }
+        groupCores.forEach { it.setSignalLocal(signal) }
+    }
+
+    private fun setSignalLocal(signal: Int) = super.setSignal(signal)
+
+    override fun isLogicalRailOccupied(): Boolean {
+        if (!isRailSection() || worldObj == null) return super.isLogicalRailOccupied()
+        return groupCores.any { it.isLocallyOccupied() }
+    }
+
+    private fun isLocallyOccupied(): Boolean = isCollidedTrain
+
+    override fun getRailRenderMinimumSplit(): Int = if (isRailSection()) 1 else 0
+
+    override fun getRailRenderEndOffset(): Int =
+        if (isRailSection() && sectionEndRatio < 1.0 - RATIO_EPSILON) 1 else 0
+
+    override fun shouldRenderRailStartCap(): Boolean =
+        !isRailSection() || sectionStartRatio <= RATIO_EPSILON
+
+    override fun shouldRenderRailEndCap(): Boolean =
+        !isRailSection() || sectionEndRatio >= 1.0 - RATIO_EPSILON
+
+    override fun breakLogicalRail() {
+        if (!isRailSection() || worldObj == null) {
+            super.breakLogicalRail()
+            return
+        }
+
+        val cores = groupCores
+        cores.forEach { it.breaking = true }
+        val logical = copyRailPositions(logicalRailPositions ?: return)
+        val fullMap = RailMapBasic(logical[0], logical[1], fixRTMRailMapVersion)
+        val candidates = LinkedHashSet<BlockPos>()
+        fullMap.getRailBlockList(property).forEach { candidates += BlockPos(it[0], it[1], it[2]) }
+        cores.forEach { core ->
+            core.getRailMap(null)?.getRailBlockList(core.property)?.forEach {
+                candidates += BlockPos(it[0], it[1], it[2])
+            }
+        }
+        railGroupCorePositions.forEach { candidates += BlockPos(it[0], it[1], it[2]) }
+
+        val targets = LinkedHashSet<BlockPos>()
+        candidates.forEach { pos ->
+            val tile = worldObj.getTileEntity(pos.x, pos.y, pos.z)
+            if (tile is TileEntityLargeRailBase) {
+                val owner = tile.railCore
+                if (owner != null && isSameLogicalRail(owner)) targets += pos
+            }
+        }
+        targets.forEach { pos ->
+            worldObj.setBlockToAir(pos.x, pos.y, pos.z)
+            worldObj.removeTileEntity(pos.x, pos.y, pos.z)
+            worldObj.markBlockForUpdate(pos.x, pos.y, pos.z)
+        }
+    }
+
+    private val groupCores: List<TileEntityLargeRailSectionCore>
+        get() {
+            if (!isRailSection() || worldObj == null) return listOf(this)
+            val result = railGroupCorePositions.mapNotNull { pos ->
+                val tile = worldObj.getTileEntity(pos[0], pos[1], pos[2])
+                (tile as? TileEntityLargeRailSectionCore)?.takeIf { isSameLogicalRail(it) }
+            }.toMutableList()
+            if (this !in result) result += this
+            return result
+        }
+
+    private fun containsCorePosition(x: Int, y: Int, z: Int): Boolean =
+        railGroupCorePositions.any { it[0] == x && it[1] == y && it[2] == z }
+
+    override fun setPos(x: Int, y: Int, z: Int, prevX: Int, prevY: Int, prevZ: Int) {
+        val difX = x - prevX
+        val difY = y - prevY
+        val difZ = z - prevZ
+        if (isRailSection()) {
+            logicalRailPositions?.forEach { it.movePos(difX, difY, difZ) }
+            railGroupCorePositions.forEach {
+                it[0] += difX
+                it[1] += difY
+                it[2] += difZ
+            }
+        }
+        super.setPos(x, y, z, prevX, prevY, prevZ)
+        railmap = null
+    }
+
+    override fun getRailShapeName(): String {
+        val positions = logicalRailPositions
+        if (!isRailSection() || positions == null) return super.getRailShapeName()
+        return "Type:Normal, " +
+            "X:${positions[1].blockX - positions[0].blockX}, " +
+            "Y:${positions[1].blockY - positions[0].blockY}, " +
+            "Z:${positions[1].blockZ - positions[0].blockZ}"
+    }
+
+    companion object {
+        const val SECTION_TAG = "RailSection"
+        private const val RATIO_EPSILON = 1.0E-7
+
+        private fun copyRailPositions(positions: Array<RailPosition>): Array<RailPosition> =
+            Array(positions.size) { RailPosition.readFromNBT(positions[it].writeToNBT()) }
+
+        private fun copyPositions(positions: List<IntArray>): Array<IntArray> =
+            Array(positions.size) { positions[it].clone() }
+    }
+
+    private data class BlockPos(val x: Int, val y: Int, val z: Int)
+}

--- a/src/main/java/jp/kaiz/kaizpatch/rtm/rail/util/RailChunkSectioner.kt
+++ b/src/main/java/jp/kaiz/kaizpatch/rtm/rail/util/RailChunkSectioner.kt
@@ -1,0 +1,195 @@
+package jp.kaiz.kaizpatch.rtm.rail.util
+
+import jp.ngt.rtm.rail.util.RailMapBasic
+import jp.ngt.rtm.rail.util.RailPosition
+import net.minecraft.util.MathHelper
+import java.util.LinkedHashSet
+import kotlin.math.ceil
+import kotlin.math.floor
+import kotlin.math.max
+import kotlin.math.min
+
+data class RailSection(
+    val startRatio: Double,
+    val endRatio: Double,
+    val startRP: RailPosition,
+    val endRP: RailPosition,
+)
+
+/** 通常レールの中心線を、通過するチャンクごとの連続区間へ分ける。 */
+object RailChunkSectioner {
+    private const val RATIO_EPSILON = 1.0E-7
+    private const val SAMPLE_PER_METER = 4.0
+
+    @JvmStatic
+    fun split(source: RailMapBasic): List<RailSection> {
+        if (source.length <= 0.0) {
+            return listOf(RailSection(0.0, 1.0, copy(source.startRP), copy(source.endRP)))
+        }
+
+        val boundaries = findBoundaries(source)
+        if (boundaries.isEmpty()) {
+            return listOf(RailSection(0.0, 1.0, copy(source.startRP), copy(source.endRP)))
+        }
+
+        val starts = mutableListOf(SectionStart(0.0, copy(source.startRP)))
+        val occupiedCoreBlocks = LinkedHashSet<BlockPos>()
+        occupiedCoreBlocks += BlockPos(source.startRP.blockX, source.startRP.blockY, source.startRP.blockZ)
+
+        for (index in boundaries.indices) {
+            val ratio = boundaries[index]
+            val nextRatio = if (index + 1 < boundaries.size) boundaries[index + 1] else 1.0
+            val core = findCoreBlock(source, ratio, nextRatio, occupiedCoreBlocks) ?: continue
+            val rp = createBoundaryRP(source, ratio, core)
+            starts += SectionStart(ratio, rp)
+            occupiedCoreBlocks += core
+        }
+
+        if (starts.size == 1) {
+            return listOf(RailSection(0.0, 1.0, starts[0].rp, copy(source.endRP)))
+        }
+
+        val result = ArrayList<RailSection>(starts.size)
+        for (index in starts.indices) {
+            val start = starts[index]
+            val endRatio = if (index + 1 < starts.size) starts[index + 1].ratio else 1.0
+            val endRP = if (index + 1 < starts.size) asSectionEnd(starts[index + 1].rp) else copy(source.endRP)
+            if (endRatio - start.ratio > RATIO_EPSILON) {
+                result += RailSection(start.ratio, endRatio, copy(start.rp), endRP)
+            }
+        }
+        return result
+    }
+
+    private fun findBoundaries(source: RailMapBasic): List<Double> {
+        val samples = max(1, ceil(source.length * SAMPLE_PER_METER).toInt())
+        val result = ArrayList<Double>()
+        var previousRatio = 0.0
+        var previousChunk = chunkAt(source, previousRatio)
+
+        for (index in 1..samples) {
+            val currentRatio = index.toDouble() / samples.toDouble()
+            var currentChunk = chunkAt(source, currentRatio)
+            var searchStart = previousRatio
+            var searchChunk = previousChunk
+            var guard = 0
+
+            while (searchChunk != currentChunk && guard++ < 4) {
+                val boundary = findFirstChunkChange(source, searchStart, currentRatio, searchChunk)
+                if (boundary > RATIO_EPSILON && boundary < 1.0 - RATIO_EPSILON &&
+                    (result.isEmpty() || boundary - result.last() > RATIO_EPSILON)
+                ) {
+                    result += boundary
+                }
+
+                val after = min(currentRatio, boundary + max(RATIO_EPSILON * 4.0, (currentRatio - previousRatio) * 1.0E-5))
+                if (after <= searchStart + RATIO_EPSILON) break
+                searchStart = after
+                searchChunk = chunkAt(source, searchStart)
+                currentChunk = chunkAt(source, currentRatio)
+            }
+
+            previousRatio = currentRatio
+            previousChunk = currentChunk
+        }
+        return result.filter { boundary ->
+            val delta = max(RATIO_EPSILON * 8.0, 1.0E-6)
+            chunkAt(source, max(0.0, boundary - delta)) != chunkAt(source, min(1.0, boundary + delta))
+        }
+    }
+
+    private fun findFirstChunkChange(source: RailMapBasic, from: Double, to: Double, fromChunk: ChunkPos): Double {
+        var low = from
+        var high = to
+        while (high - low > RATIO_EPSILON) {
+            val middle = (low + high) * 0.5
+            if (chunkAt(source, middle) == fromChunk) {
+                low = middle
+            } else {
+                high = middle
+            }
+        }
+        return high
+    }
+
+    private fun findCoreBlock(
+        source: RailMapBasic,
+        startRatio: Double,
+        endRatio: Double,
+        occupied: Set<BlockPos>,
+    ): BlockPos? {
+        val length = endRatio - startRatio
+        if (length <= RATIO_EPSILON) return null
+
+        val targetRatio = min(endRatio, startRatio + max(RATIO_EPSILON * 8.0, length * 1.0E-4))
+        val targetChunk = chunkAt(source, targetRatio)
+        for (index in 0..32) {
+            val local = if (index == 0) 1.0E-4 else index.toDouble() / 32.0
+            val ratio = min(endRatio, startRatio + length * local)
+            val point = source.getRailPos(ratio)
+            val candidate = BlockPos(
+                floor(point[1]).toInt(),
+                floor(source.getRailHeight(ratio)).toInt(),
+                floor(point[0]).toInt(),
+            )
+            if (candidate.chunk == targetChunk && candidate !in occupied) {
+                return candidate
+            }
+        }
+        return null
+    }
+
+    private fun createBoundaryRP(source: RailMapBasic, ratio: Double, core: BlockPos): RailPosition {
+        val yaw = source.getRailYaw(ratio)
+        val direction = (MathHelper.floor_double((normalizeAngle(yaw) / 45.0F + 0.5F).toDouble()) and 7).toByte()
+        val point = source.getRailPos(ratio)
+        val rp = RailPosition(core.x, core.y, core.z, direction)
+        rp.anchorYaw = MathHelper.wrapAngleTo180_float(yaw)
+        rp.anchorPitch = MathHelper.wrapAngleTo180_float(source.getRailPitch(ratio))
+        rp.anchorLengthHorizontal = 0.0F
+        rp.anchorLengthVertical = 0.0F
+        rp.cantEdge = source.getRailRoll(ratio)
+        copyLimits(source.startRP, rp)
+        rp.setPosition(point[1], source.getRailHeight(ratio), point[0])
+        return rp
+    }
+
+    private fun normalizeAngle(angle: Float): Float {
+        var result = angle % 360.0F
+        if (result < 0.0F) result += 360.0F
+        return result
+    }
+
+    private fun chunkAt(source: RailMapBasic, ratio: Double): ChunkPos {
+        val point = source.getRailPos(ratio)
+        return ChunkPos(floor(point[1]).toInt() shr 4, floor(point[0]).toInt() shr 4)
+    }
+
+    private fun copy(source: RailPosition): RailPosition = RailPosition.readFromNBT(source.writeToNBT())
+
+    private fun asSectionEnd(sectionStart: RailPosition): RailPosition {
+        val result = copy(sectionStart)
+        val x = result.posX
+        val y = result.posY
+        val z = result.posZ
+        result.direction = ((result.direction.toInt() + 4) and 7).toByte()
+        result.anchorYaw = MathHelper.wrapAngleTo180_float(result.anchorYaw + 180.0F)
+        result.setPosition(x, y, z)
+        return result
+    }
+
+    private fun copyLimits(source: RailPosition, target: RailPosition) {
+        target.constLimitHP = source.constLimitHP
+        target.constLimitHN = source.constLimitHN
+        target.constLimitWP = source.constLimitWP
+        target.constLimitWN = source.constLimitWN
+        target.cantCenter = source.cantCenter
+        target.cantRandom = source.cantRandom
+    }
+
+    private data class SectionStart(val ratio: Double, val rp: RailPosition)
+    private data class ChunkPos(val x: Int, val z: Int)
+    private data class BlockPos(val x: Int, val y: Int, val z: Int) {
+        val chunk: ChunkPos get() = ChunkPos(x shr 4, z shr 4)
+    }
+}

--- a/src/main/java/jp/kaiz/kaizpatch/rtm/rail/util/RailMapSection.kt
+++ b/src/main/java/jp/kaiz/kaizpatch/rtm/rail/util/RailMapSection.kt
@@ -1,0 +1,63 @@
+package jp.kaiz.kaizpatch.rtm.rail.util
+
+import jp.ngt.rtm.rail.util.RailMap
+import jp.ngt.rtm.rail.util.RailMapBasic
+import jp.ngt.rtm.rail.util.RailPosition
+import kotlin.math.max
+import kotlin.math.min
+
+/**
+ * 元のRailMapBasicの一部分だけを公開するRailMap。
+ * 曲線を再構築せず元RailMapへ委譲することで、勾配・カントを含めた連続性を維持する。
+ */
+class RailMapSection(
+    val source: RailMapBasic,
+    private val sectionStartRP: RailPosition,
+    private val sectionEndRP: RailPosition,
+    val startRatio: Double,
+    val endRatio: Double,
+) : RailMap() {
+    private val ratioLength = max(0.0, endRatio - startRatio)
+
+    override fun getStartRP(): RailPosition = sectionStartRP
+
+    override fun getEndRP(): RailPosition = sectionEndRP
+
+    override fun getLength(): Double = source.length * ratioLength
+
+    private fun sourceRatio(split: Int, index: Int): Double {
+        val localRatio = if (split <= 0) 0.0 else index.toDouble() / split.toDouble()
+        return sourceRatio(localRatio)
+    }
+
+    fun sourceRatio(localRatio: Double): Double {
+        return startRatio + ratioLength * max(0.0, min(1.0, localRatio))
+    }
+
+    override fun getNearlestPoint(split: Int, x: Double, z: Double): Int {
+        if (split <= 0) return 0
+        var nearest = 0
+        var distance = Double.MAX_VALUE
+        for (index in 0..split) {
+            val point = getRailPos(split, index)
+            val dx = x - point[1]
+            val dz = z - point[0]
+            val current = dx * dx + dz * dz
+            if (current < distance) {
+                distance = current
+                nearest = index
+            }
+        }
+        return nearest
+    }
+
+    override fun getRailPos(split: Int, index: Int): DoubleArray = source.getRailPos(sourceRatio(split, index))
+
+    override fun getRailHeight(split: Int, index: Int): Double = source.getRailHeight(sourceRatio(split, index))
+
+    override fun getRailYaw(split: Int, index: Int): Float = source.getRailYaw(sourceRatio(split, index))
+
+    override fun getRailPitch(split: Int, index: Int): Float = source.getRailPitch(sourceRatio(split, index))
+
+    override fun getRailRoll(split: Int, index: Int): Float = source.getRailRoll(sourceRatio(split, index))
+}

--- a/src/main/java/jp/kaiz/kaizpatch/rtm/rail/util/RailTransitionResolver.kt
+++ b/src/main/java/jp/kaiz/kaizpatch/rtm/rail/util/RailTransitionResolver.kt
@@ -1,0 +1,97 @@
+package jp.kaiz.kaizpatch.rtm.rail.util
+
+import jp.ngt.rtm.rail.TileEntityLargeRailBase
+import jp.ngt.rtm.rail.TileEntityLargeRailCore
+import jp.ngt.rtm.rail.util.RailMap
+import jp.ngt.rtm.rail.util.RailPosition
+import net.minecraft.util.MathHelper
+import net.minecraft.world.World
+import kotlin.math.*
+
+/** 現在のレール端点から、進行方向側に接続されたレールを解決する。 */
+object RailTransitionResolver {
+    private const val SPLITS_PER_METER = 360.0
+    private const val ENDPOINT_MARGIN_METERS = 0.5
+    private val verticalOffsets = intArrayOf(0, 1, -1, 2, -2, 3, -3)
+
+    @JvmStatic
+    fun findConnectedCore(
+        world: World,
+        currentCore: TileEntityLargeRailCore?,
+        currentMap: RailMap?,
+        split: Int,
+        previousIndex: Int,
+        currentX: Double,
+        currentZ: Double,
+        targetX: Double,
+        targetZ: Double,
+        movingYaw: Float,
+    ): TileEntityLargeRailCore? {
+        if (currentCore == null || currentMap == null || split <= 0 || previousIndex < 0) return null
+
+        val movement = hypot(targetX - currentX, targetZ - currentZ)
+        val travelYaw = if (movement > 1.0E-7) {
+            Math.toDegrees(atan2(targetX - currentX, targetZ - currentZ)).toFloat()
+        } else {
+            movingYaw
+        }
+        val exits = selectExitDirections(currentMap, split, previousIndex, movement, travelYaw)
+        for (towardEnd in exits) {
+            val endpoint = if (towardEnd) currentMap.endRP else currentMap.startRP
+            findCoreAcrossEndpoint(world, currentCore, currentMap, endpoint)?.let { return it }
+        }
+        return null
+    }
+
+    internal fun selectExitDirections(
+        currentMap: RailMap,
+        split: Int,
+        previousIndex: Int,
+        movement: Double,
+        travelYaw: Float,
+    ): List<Boolean> {
+        val indexMargin = ceil((movement + ENDPOINT_MARGIN_METERS) * SPLITS_PER_METER).toInt()
+        return buildList {
+            if (previousIndex <= indexMargin) {
+                add(false)
+            }
+            if (split - previousIndex <= indexMargin) {
+                add(true)
+            }
+        }
+            .sortedBy { abs(MathHelper.wrapAngleTo180_float(travelYaw - outwardYaw(currentMap, split, it))) }
+            .filter { abs(MathHelper.wrapAngleTo180_float(travelYaw - outwardYaw(currentMap, split, it))) <= 90.0F }
+    }
+
+    private fun outwardYaw(map: RailMap, split: Int, towardEnd: Boolean): Float {
+        val index = if (towardEnd) max(0, split - 1) else min(1, split)
+        val yaw = map.getRailYaw(split, index) + if (towardEnd) 0.0F else 180.0F
+        return MathHelper.wrapAngleTo180_float(yaw)
+    }
+
+    private fun findCoreAcrossEndpoint(
+        world: World,
+        currentCore: TileEntityLargeRailCore,
+        currentMap: RailMap,
+        endpoint: RailPosition,
+    ): TileEntityLargeRailCore? {
+        val neighbor = endpoint.neighborPos
+        val expectedY = floor(endpoint.posY).toInt()
+        val yCandidates = LinkedHashSet<Int>().apply {
+            add(neighbor[1])
+            verticalOffsets.forEach { add(expectedY + it) }
+        }
+        world.chunkProvider.loadChunk(neighbor[0] shr 4, neighbor[2] shr 4)
+        for (y in yCandidates) {
+            val rail = world.getTileEntity(neighbor[0], y, neighbor[2]) as? TileEntityLargeRailBase ?: continue
+            val candidate = rail.railCore ?: continue
+            if (candidate === currentCore) continue
+            if (currentCore.isSameLogicalRail(candidate) || connects(currentMap, candidate)) return candidate
+        }
+        return null
+    }
+
+    private fun connects(currentMap: RailMap, candidate: TileEntityLargeRailCore): Boolean =
+        candidate.allRailMaps?.any { currentMap.canConnect(it) } == true
+
+}

--- a/src/main/java/jp/ngt/ngtlib/math/BezierCurve.java
+++ b/src/main/java/jp/ngt/ngtlib/math/BezierCurve.java
@@ -38,7 +38,13 @@ public final class BezierCurve implements ILine {
 
     @Override
     public double[] getPoint(int par1, int par2) {
-        return this.getPointFromParameter(this.getHomogenizedParameter(par1, par2));
+        double ratio = par1 == 0 ? 0.0D : (double) par2 / (double) par1;
+        return this.getPoint(ratio);
+    }
+
+    @Override
+    public double[] getPoint(double ratio) {
+        return this.getPointFromParameter(this.getHomogenizedParameter(ratio));
     }
 
     /**
@@ -79,7 +85,13 @@ public final class BezierCurve implements ILine {
 
     @Override
     public double getSlope(int par1, int par2) {
-        return this.getSlopeFromParameter(this.getHomogenizedParameter(par1, par2));
+        double ratio = par1 == 0 ? 0.0D : (double) par2 / (double) par1;
+        return this.getSlope(ratio);
+    }
+
+    @Override
+    public double getSlope(double ratio) {
+        return this.getSlopeFromParameter(this.getHomogenizedParameter(ratio));
     }
 
     /**
@@ -101,14 +113,10 @@ public final class BezierCurve implements ILine {
     /**
      * @param n 分割数
      */
-    private float getHomogenizedParameter(int n, int par2) {
-        if (n < 4) {
+    private float getHomogenizedParameter(double ratio) {
+        if (ratio <= 0.0D) {
             return 0.0F;
-        }
-
-        if (par2 <= 0) {
-            return 0.0F;
-        } else if (par2 >= n) {
+        } else if (ratio >= 1.0D) {
             return 1.0F;
         }
 
@@ -116,13 +124,15 @@ public final class BezierCurve implements ILine {
             this.initNP();
         }
 
-        int i0 = MathHelper.floor_float((float) par2 * (float) this.split / (float) n);
-
         if (this.normalizedParameters.length == 0) {
             return 0.0f;
         }
 
-        return this.normalizedParameters[i0];
+        double scaled = ratio * (double) this.split;
+        int i0 = MathHelper.floor_double(scaled);
+        float p0 = this.normalizedParameters[Math.min(i0, this.normalizedParameters.length - 1)];
+        float p1 = i0 + 1 < this.normalizedParameters.length ? this.normalizedParameters[i0 + 1] : 1.0F;
+        return p0 + (p1 - p0) * (float) (scaled - (double) i0);
     }
 
     private void initNP() {

--- a/src/main/java/jp/ngt/ngtlib/math/ILine.java
+++ b/src/main/java/jp/ngt/ngtlib/math/ILine.java
@@ -9,6 +9,15 @@ public interface ILine {
     double[] getPoint(int par1, int par2);
 
     /**
+     * 曲線長で正規化した位置(0.0～1.0)から座標を取得する。
+     */
+    default double[] getPoint(double ratio) {
+        double value = Math.max(0.0D, Math.min(1.0D, ratio));
+        int split = 1000000;
+        return this.getPoint(split, (int) Math.round(value * (double) split));
+    }
+
+    /**
      * @param par1 分割数
      * @param par2 x
      * @param par3 z
@@ -22,6 +31,15 @@ public interface ILine {
      * @return 傾き（ラジアン）
      */
     double getSlope(int par1, int par2);
+
+    /**
+     * 曲線長で正規化した位置(0.0～1.0)から傾きを取得する。
+     */
+    default double getSlope(double ratio) {
+        double value = Math.max(0.0D, Math.min(1.0D, ratio));
+        int split = 1000000;
+        return this.getSlope(split, (int) Math.round(value * (double) split));
+    }
 
     /**
      * @return 線分の長さ

--- a/src/main/java/jp/ngt/ngtlib/math/StraightLine.java
+++ b/src/main/java/jp/ngt/ngtlib/math/StraightLine.java
@@ -40,8 +40,13 @@ public final class StraightLine implements ILine {
 
     @Override
     public double[] getPoint(int par1, int par2) {
-        int i0 = par2 < 0 ? 0 : (Math.min(par2, par1));
-        double d0 = (double) i0 / (double) par1;
+        double d0 = par1 == 0 ? 0.0D : (double) par2 / (double) par1;
+        return this.getPoint(d0);
+    }
+
+    @Override
+    public double[] getPoint(double ratio) {
+        double d0 = Math.max(0.0D, Math.min(1.0D, ratio));
         double x = this.startX + ((this.endX - this.startX) * d0);
         double y = this.startY + ((this.endY - this.startY) * d0);
         return new double[]{x, y};
@@ -64,6 +69,11 @@ public final class StraightLine implements ILine {
 
     @Override
     public double getSlope(int par1, int par2) {
+        return this.slopeAngle;
+    }
+
+    @Override
+    public double getSlope(double ratio) {
         return this.slopeAngle;
     }
 

--- a/src/main/java/jp/ngt/rtm/ClientProxy.java
+++ b/src/main/java/jp/ngt/rtm/ClientProxy.java
@@ -7,6 +7,7 @@ import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import jp.kaiz.kaizpatch.compat.AngelicaCompat;
+import jp.kaiz.kaizpatch.rtm.rail.TileEntityLargeRailSectionCore;
 import jp.ngt.ngtlib.io.NGTFileLoadException;
 import jp.ngt.ngtlib.io.NGTFileLoader;
 import jp.ngt.ngtlib.io.NGTJson;
@@ -100,6 +101,7 @@ public class ClientProxy extends CommonProxy {
 
 //        ClientRegistry.bindTileEntitySpecialRenderer(TileEntityFluorescent.class, new RenderFluorescent());
         ClientRegistry.bindTileEntitySpecialRenderer(TileEntityLargeRailNormalCore.class, RenderLargeRail.INSTANCE);
+        ClientRegistry.bindTileEntitySpecialRenderer(TileEntityLargeRailSectionCore.class, RenderLargeRail.INSTANCE);
         ClientRegistry.bindTileEntitySpecialRenderer(TileEntityLargeRailSwitchCore.class, RenderLargeRail.INSTANCE);
         ClientRegistry.bindTileEntitySpecialRenderer(TileEntityLargeRailSlopeCore.class, RenderLargeRail.INSTANCE);
         ClientRegistry.bindTileEntitySpecialRenderer(TileEntityTurnTableCore.class, new RenderTurntable());

--- a/src/main/java/jp/ngt/rtm/RTMRail.java
+++ b/src/main/java/jp/ngt/rtm/RTMRail.java
@@ -1,6 +1,7 @@
 package jp.ngt.rtm;
 
 import cpw.mods.fml.common.registry.GameRegistry;
+import jp.kaiz.kaizpatch.rtm.rail.TileEntityLargeRailSectionCore;
 import jp.ngt.rtm.rail.*;
 import jp.ngt.rtm.rail.util.RailProperty;
 import net.minecraft.block.Block;
@@ -64,6 +65,7 @@ public final class RTMRail {
 
         GameRegistry.registerTileEntity(TileEntityLargeRailBase.class, "TERailBase");
         GameRegistry.registerTileEntity(TileEntityLargeRailNormalCore.class, "TERailCore");
+        GameRegistry.registerTileEntity(TileEntityLargeRailSectionCore.class, "TERailSectionCore");
         GameRegistry.registerTileEntity(TileEntityLargeRailSwitchBase.class, "TERailSwitchBase");
         GameRegistry.registerTileEntity(TileEntityLargeRailSwitchCore.class, "TERailSwitchCore");
         GameRegistry.registerTileEntity(TileEntityLargeRailSlopeBase.class, "TERailSlopeBase");

--- a/src/main/java/jp/ngt/rtm/entity/train/EntityBogie.java
+++ b/src/main/java/jp/ngt/rtm/entity/train/EntityBogie.java
@@ -279,6 +279,7 @@ public class EntityBogie extends Entity implements Lockable {
             {
             } else//新しいレール上に移動
             {
+                boolean sameLogicalRail = this.currentRailObj != null && this.currentRailObj.isSameLogicalRail(coreObj);
                 RailMap railMap;
                 if (coreObj instanceof TileEntityLargeRailSwitchCore) {
                     TileEntityLargeRailSwitchCore switchObj = (TileEntityLargeRailSwitchCore) coreObj;
@@ -287,7 +288,7 @@ public class EntityBogie extends Entity implements Lockable {
                     railMap = coreObj.getRailMap(this);
                 }
 
-                if (this.currentRailMap != null && !this.currentRailMap.canConnect(railMap)) {
+                if (this.currentRailMap != null && !sameLogicalRail && !this.currentRailMap.canConnect(railMap)) {
                     return true;
                 }
 
@@ -295,7 +296,9 @@ public class EntityBogie extends Entity implements Lockable {
                 this.currentRailMap = railMap;
                 this.split = (int) (this.currentRailMap.getLength() * (double) SPLITS_PER_METER);
                 this.prevPosIndex = -1;
-                this.onChangeRail(coreObj);
+                if (!sameLogicalRail) {
+                    this.onChangeRail(coreObj);
+                }
             }
 
             return true;

--- a/src/main/java/jp/ngt/rtm/entity/train/EntityBogie.java
+++ b/src/main/java/jp/ngt/rtm/entity/train/EntityBogie.java
@@ -2,6 +2,7 @@ package jp.ngt.rtm.entity.train;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import jp.kaiz.kaizpatch.rtm.rail.util.RailTransitionResolver;
 import jp.ngt.ngtlib.io.NGTLog;
 import jp.ngt.ngtlib.math.NGTMath;
 import jp.ngt.ngtlib.math.Vec3;
@@ -360,6 +361,21 @@ public class EntityBogie extends Entity implements Lockable {
         this.worldObj.getChunkProvider().loadChunk(x >> 4, z >> 4);
         TileEntityLargeRailBase railObj = TileEntityLargeRailBase.getRailFromCoordinates(this.worldObj, px, py, pz);
         if (railObj == null) {
+            TileEntityLargeRailCore connectedCore = RailTransitionResolver.findConnectedCore(
+                    this.worldObj,
+                    this.currentRailObj,
+                    this.currentRailMap,
+                    this.split,
+                    this.prevPosIndex,
+                    this.posX,
+                    this.posZ,
+                    px,
+                    pz,
+                    this.movingYaw
+            );
+            if (connectedCore != null) {
+                return connectedCore;
+            }
             this.errorLog(px, pz, "Rail not found > x:%s z:%s");
             return null;
         }

--- a/src/main/java/jp/ngt/rtm/gui/GuiSelectRailModel.kt
+++ b/src/main/java/jp/ngt/rtm/gui/GuiSelectRailModel.kt
@@ -1,0 +1,45 @@
+package jp.ngt.rtm.gui
+
+import cpw.mods.fml.client.config.GuiCheckBox
+import cpw.mods.fml.relauncher.Side
+import cpw.mods.fml.relauncher.SideOnly
+import jp.ngt.rtm.item.ItemRail
+import jp.ngt.rtm.modelpack.state.ResourceState
+import net.minecraft.client.gui.GuiButton
+import net.minecraft.world.World
+
+@SideOnly(Side.CLIENT)
+class GuiSelectRailModel(world: World, private val rail: ItemRail) : GuiSelectModel(world, rail) {
+    private lateinit var disableAutoSplitButton: GuiCheckBox
+
+    override fun initGui() {
+        super.initGui()
+        disableAutoSplitButton = GuiCheckBox(
+            AUTO_SPLIT_BUTTON_ID,
+            width - 205,
+            55,
+            "Disable Auto Split",
+            !rail.isSelectedItemAutoSplitEnabled,
+        )
+        buttonList.add(disableAutoSplitButton)
+    }
+
+    override fun actionPerformed(button: GuiButton) {
+        if (button.id == AUTO_SPLIT_BUTTON_ID) return
+        if (button is GuiButtonSelectModel) applyRailOptions()
+        super.actionPerformed(button)
+    }
+
+    override fun saveData(state: ResourceState): Boolean {
+        applyRailOptions()
+        return super.saveData(state)
+    }
+
+    private fun applyRailOptions() {
+        rail.setSelectedItemAutoSplitEnabled(!disableAutoSplitButton.isChecked)
+    }
+
+    private companion object {
+        const val AUTO_SPLIT_BUTTON_ID = 10002
+    }
+}

--- a/src/main/java/jp/ngt/rtm/gui/RTMGuiHandler.java
+++ b/src/main/java/jp/ngt/rtm/gui/RTMGuiHandler.java
@@ -16,6 +16,7 @@ import jp.ngt.rtm.entity.train.EntityFreightCar;
 import jp.ngt.rtm.entity.train.EntityTrainBase;
 import jp.ngt.rtm.entity.train.parts.EntityContainer;
 import jp.ngt.rtm.gui.rail.GuiRailMarker;
+import jp.ngt.rtm.item.ItemRail;
 import jp.ngt.rtm.modelpack.DataFormProvider;
 import jp.ngt.rtm.modelpack.IModelSelector;
 import jp.ngt.rtm.modelpack.IModelSelectorWithType;
@@ -80,6 +81,9 @@ public class RTMGuiHandler implements IGuiHandler {
             }
         } else if (ID == RTMCore.guiIdSelectItemModel) {
             Item item = player.inventory.getCurrentItem().getItem();
+            if (item instanceof ItemRail) {
+                return new GuiSelectRailModel(world, (ItemRail) item);
+            }
             return new GuiSelectModel(world, (IModelSelectorWithType) item);
         } else if (ID == RTMCore.guiIdRailItemSettings) {
             return new GuiRailItemSettings(player.inventory);

--- a/src/main/java/jp/ngt/rtm/item/ItemRail.java
+++ b/src/main/java/jp/ngt/rtm/item/ItemRail.java
@@ -200,7 +200,7 @@ public class ItemRail extends ItemWithModel {
 
     public static ItemStack copyItemFromRail(TileEntityLargeRailCore core) {
         ItemStack stack = ItemRail.getRailItem(core.getProperty());
-        RailPosition[] rps = core.getRailPositions();
+        RailPosition[] rps = core.getLogicalRailPositions();
         setRPToItem(stack, rps);
         String shape = core.getRailShapeName();
         stack.getTagCompound().setString("ShapeName", shape);
@@ -217,6 +217,7 @@ public class ItemRail extends ItemWithModel {
             int origY = topRP.blockY;
             int origZ = topRP.blockZ;
             for (RailPosition rp : rps) {
+                Vec3 offset = PooledVec3.create(rp.offsetX, rp.offsetY, rp.offsetZ).rotateAroundY(difDir * 45.0F);
                 double dif2X = (rp.blockX + 0.5D) - (origX + 0.5D);
                 double dif2Y = (rp.blockY + 0.5D) - (origY + 0.5D);
                 double dif2Z = (rp.blockZ + 0.5D) - (origZ + 0.5D);
@@ -227,6 +228,9 @@ public class ItemRail extends ItemWithModel {
                 rp.blockZ = MathHelper.floor_double(z + 0.5D + vec.getZ());
                 rp.direction = (byte) ((rp.direction + difDir + 8) & 7);
                 rp.anchorYaw = MathHelper.wrapAngleTo180_float(rp.anchorYaw + difDir * 45.0F);
+                rp.offsetX = offset.getX();
+                rp.offsetY = offset.getY();
+                rp.offsetZ = offset.getZ();
                 rp.init();
             }
             RailProperty state = ItemRail.getProperty(stack);

--- a/src/main/java/jp/ngt/rtm/item/ItemRail.java
+++ b/src/main/java/jp/ngt/rtm/item/ItemRail.java
@@ -160,8 +160,29 @@ public class ItemRail extends ItemWithModel {
         if (prop == null) {
             prop = getDefaultProperty();
         }
-        prop = new RailProperty(name, prop.block, prop.blockMetadata, prop.blockHeight);
+        prop = new RailProperty(name, prop.block, prop.blockMetadata, prop.blockHeight, prop.autoSplit);
         writePropToItem(prop, itemStack);
+    }
+
+    @SideOnly(Side.CLIENT)
+    public boolean isSelectedItemAutoSplitEnabled() {
+        ItemStack itemStack = this.getSelectedItem();
+        RailProperty prop = itemStack == null ? null : getProperty(itemStack);
+        return prop == null || prop.autoSplit;
+    }
+
+    @SideOnly(Side.CLIENT)
+    public void setSelectedItemAutoSplitEnabled(boolean autoSplit) {
+        ItemStack itemStack = this.getSelectedItem();
+        if (itemStack == null) {
+            return;
+        }
+
+        RailProperty prop = getProperty(itemStack);
+        if (prop == null) {
+            prop = getDefaultProperty();
+        }
+        writePropToItem(new RailProperty(prop.railModel, prop.block, prop.blockMetadata, prop.blockHeight, autoSplit), itemStack);
     }
 
     @Override

--- a/src/main/java/jp/ngt/rtm/item/ItemWithModel.java
+++ b/src/main/java/jp/ngt/rtm/item/ItemWithModel.java
@@ -26,6 +26,11 @@ public abstract class ItemWithModel extends Item implements IModelSelectorWithTy
     @SideOnly(Side.CLIENT)
     private EntityPlayer selectedPlayer;
 
+    @SideOnly(Side.CLIENT)
+    protected ItemStack getSelectedItem() {
+        return this.selectedItem;
+    }
+
     public ItemWithModel() {
         super();
         this.setHasSubtypes(true);

--- a/src/main/java/jp/ngt/rtm/item/ItemWrench.java
+++ b/src/main/java/jp/ngt/rtm/item/ItemWrench.java
@@ -91,7 +91,7 @@ public class ItemWrench extends Item {
             TileEntityLargeRailCore targetRailCore = targetRail.getRailCore();
             if (targetRailCore != null) {
                 world.setBlockToAir(x, y, z);
-                RailPosition[] rps = targetRailCore.getRailPositions();
+                RailPosition[] rps = targetRailCore.getLogicalRailPositions();
                 Arrays.stream(rps).forEach(rp -> {
                     if (rp != null) {
                         int meta = directionMetaMap[rp.direction];

--- a/src/main/java/jp/ngt/rtm/network/PacketLargeRailCore.java
+++ b/src/main/java/jp/ngt/rtm/network/PacketLargeRailCore.java
@@ -5,9 +5,9 @@ import cpw.mods.fml.common.network.simpleimpl.IMessage;
 import cpw.mods.fml.common.network.simpleimpl.IMessageHandler;
 import cpw.mods.fml.common.network.simpleimpl.MessageContext;
 import io.netty.buffer.ByteBuf;
+import jp.kaiz.kaizpatch.rtm.rail.TileEntityLargeRailSectionCore;
 import jp.ngt.ngtlib.util.NGTUtil;
 import jp.ngt.rtm.rail.TileEntityLargeRailCore;
-import jp.ngt.rtm.rail.TileEntityLargeRailNormalCore;
 import jp.ngt.rtm.rail.TileEntityLargeRailSlopeCore;
 import jp.ngt.rtm.rail.TileEntityLargeRailSwitchCore;
 import jp.ngt.rtm.rail.util.RailPosition;
@@ -47,6 +47,9 @@ public class PacketLargeRailCore implements IMessage, IMessageHandler<PacketLarg
         this.property = new NBTTagCompound();
         NBTTagCompound nbt = new NBTTagCompound();
         tile.writeRailProperties(nbt);
+        if (tile instanceof TileEntityLargeRailSectionCore) {
+            ((TileEntityLargeRailSectionCore) tile).writeSectionData(nbt);
+        }
         this.property = nbt;
         this.railPositions = tile.getRailPositions();
 
@@ -114,7 +117,8 @@ public class PacketLargeRailCore implements IMessage, IMessageHandler<PacketLarg
             tile0.setStartPoint(message.sX, message.sY, message.sZ);
             tile0.readRailProperties(message.property);
             tile0.setRailPositions(message.railPositions);
-            if (message.dataType == TYPE_NORMAL && tile instanceof TileEntityLargeRailNormalCore) {
+            if (message.dataType == TYPE_NORMAL && tile instanceof TileEntityLargeRailSectionCore) {
+                ((TileEntityLargeRailSectionCore) tile).readSectionData(message.property);
             } else if (message.dataType == TYPE_SLOPE && tile instanceof TileEntityLargeRailSlopeCore) {
                 TileEntityLargeRailSlopeCore tile1 = (TileEntityLargeRailSlopeCore) tile;
                 tile1.setSlopeType(message.type);

--- a/src/main/java/jp/ngt/rtm/rail/BlockLargeRailBase.java
+++ b/src/main/java/jp/ngt/rtm/rail/BlockLargeRailBase.java
@@ -26,7 +26,6 @@ import net.minecraft.util.MovingObjectPosition;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.Random;
 import java.util.stream.IntStream;
@@ -183,7 +182,7 @@ public class BlockLargeRailBase extends BlockContainer {
         TileEntityLargeRailCore core = tile0.getRailCore();
         if (!world.isRemote && core != null && !core.breaking) {
             core.breaking = true;
-            Arrays.stream(core.getAllRailMaps()).forEach(rm -> rm.breakRail(world, core.getProperty(), core));
+            core.breakLogicalRail();
         }
         super.breakBlock(world, x, y, z, block, meta);
     }

--- a/src/main/java/jp/ngt/rtm/rail/BlockLargeRailCore.java
+++ b/src/main/java/jp/ngt/rtm/rail/BlockLargeRailCore.java
@@ -1,5 +1,6 @@
 package jp.ngt.rtm.rail;
 
+import jp.kaiz.kaizpatch.rtm.rail.TileEntityLargeRailSectionCore;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.world.World;
 
@@ -10,7 +11,7 @@ public class BlockLargeRailCore extends BlockLargeRailBase {
 
     @Override
     public TileEntity createNewTileEntity(World world, int par2) {
-        return new TileEntityLargeRailNormalCore();
+        return par2 == 1 ? new TileEntityLargeRailSectionCore() : new TileEntityLargeRailNormalCore();
     }
 
     @Override

--- a/src/main/java/jp/ngt/rtm/rail/BlockMarker.java
+++ b/src/main/java/jp/ngt/rtm/rail/BlockMarker.java
@@ -6,6 +6,10 @@ import jp.ngt.ngtlib.io.NGTLog;
 import jp.ngt.ngtlib.math.NGTMath;
 import jp.ngt.ngtlib.math.NGTVec;
 import jp.ngt.ngtlib.util.PermissionManager;
+import jp.kaiz.kaizpatch.rtm.rail.util.RailChunkSectioner;
+import jp.kaiz.kaizpatch.rtm.rail.util.RailMapSection;
+import jp.kaiz.kaizpatch.rtm.rail.util.RailSection;
+import jp.kaiz.kaizpatch.rtm.rail.TileEntityLargeRailSectionCore;
 import jp.ngt.rtm.*;
 import jp.ngt.rtm.item.ItemBlockMarker;
 import jp.ngt.rtm.item.ItemRail;
@@ -29,6 +33,7 @@ import net.minecraft.world.World;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 public class BlockMarker extends BlockContainer {
@@ -212,7 +217,7 @@ public class BlockMarker extends BlockContainer {
             if (rps.stream().allMatch(rp -> rp.switchType == 1)) {
                 return createTurntable(world, rps.get(0), rps.get(1), prop, makeRail, isCreative);
             } else {
-                createRail0(world, rps.get(0), rps.get(1), prop, makeRail, isCreative);
+                return createRail0(world, rps.get(0), rps.get(1), prop, makeRail, isCreative);
             }
         } else if (rps.size() > 2) {
             createRail1(world, x, y, z, null, rps, prop, makeRail, isCreative);
@@ -229,6 +234,10 @@ public class BlockMarker extends BlockContainer {
         RailMapBasic railMap = new RailMapBasic(start, end, RailMapBasic.fixRTMRailMapVersionCurrent);
 
         if (makeRail && railMap.canPlaceRail(world, isCreative, prop)) {
+            List<RailSection> sections = RailChunkSectioner.split(railMap);
+            if (sections.size() > 1) {
+                return createSectionedRail(world, railMap, sections, prop, isCreative);
+            }
             //railMap.setRail(world, RTMRail.largeRailBase[shape[0]], x0, y0, z0);
             railMap.setRail(world, RTMRail.largeRailBase0, start.blockX, start.blockY, start.blockZ, prop);
 
@@ -259,6 +268,68 @@ public class BlockMarker extends BlockContainer {
             }
             return false;
         }
+    }
+
+    private static boolean createSectionedRail(World world, RailMapBasic source, List<RailSection> sections,
+                                                RailProperty prop, boolean isCreative) {
+        UUID groupId = UUID.randomUUID();
+        RailPosition[] logicalPositions = new RailPosition[]{
+                copyRailPosition(source.getStartRP()),
+                copyRailPosition(source.getEndRP())
+        };
+        List<int[]> corePositions = sections.stream()
+                .map(section -> new int[]{section.getStartRP().blockX, section.getStartRP().blockY, section.getStartRP().blockZ})
+                .collect(Collectors.toList());
+
+        for (RailSection section : sections) {
+            RailMapSection sectionMap = new RailMapSection(source, section.getStartRP(), section.getEndRP(),
+                    section.getStartRatio(), section.getEndRatio());
+            if (!sectionMap.canPlaceRail(world, isCreative, prop)) {
+                return false;
+            }
+        }
+
+        RailPosition logicalStart = logicalPositions[0];
+        source.prepareBaseBlocks(world, logicalStart.blockX, logicalStart.blockY, logicalStart.blockZ);
+        for (RailSection section : sections) {
+            RailMapSection sectionMap = new RailMapSection(source, section.getStartRP(), section.getEndRP(),
+                    section.getStartRatio(), section.getEndRatio());
+            int[] corePos = new int[]{section.getStartRP().blockX, section.getStartRP().blockY, section.getStartRP().blockZ};
+            sectionMap.setRail(world, RTMRail.largeRailBase0, corePos[0], corePos[1], corePos[2], prop);
+        }
+
+        for (RailSection section : sections) {
+            RailPosition sectionStart = copyRailPosition(section.getStartRP());
+            RailPosition sectionEnd = copyRailPosition(section.getEndRP());
+            int coreX = sectionStart.blockX;
+            int coreY = sectionStart.blockY;
+            int coreZ = sectionStart.blockZ;
+            world.setBlock(coreX, coreY, coreZ, RTMRail.largeRailCore0, 1, 2);
+            TileEntity tileEntity = world.getTileEntity(coreX, coreY, coreZ);
+            if (!(tileEntity instanceof TileEntityLargeRailSectionCore)) {
+                return false;
+            }
+
+            TileEntityLargeRailSectionCore tile = (TileEntityLargeRailSectionCore) tileEntity;
+            tile.configureRailSection(groupId, logicalPositions, new RailPosition[]{sectionStart, sectionEnd},
+                    section.getStartRatio(), section.getEndRatio(), corePositions);
+            tile.setProperty(prop);
+            tile.setStartPoint(coreX, coreY, coreZ);
+            tile.fixRTMRailMapVersion = source.fixRTMRailMapVersion;
+            tile.createRailMap();
+            tile.markDirty();
+            world.markBlockForUpdate(coreX, coreY, coreZ);
+        }
+
+        RailPosition logicalEnd = logicalPositions[1];
+        if (world.getBlock(logicalEnd.blockX, logicalEnd.blockY, logicalEnd.blockZ) instanceof BlockMarker) {
+            world.setBlockToAir(logicalEnd.blockX, logicalEnd.blockY, logicalEnd.blockZ);
+        }
+        return true;
+    }
+
+    private static RailPosition copyRailPosition(RailPosition source) {
+        return RailPosition.readFromNBT(source.writeToNBT());
     }
 
     /**

--- a/src/main/java/jp/ngt/rtm/rail/BlockMarker.java
+++ b/src/main/java/jp/ngt/rtm/rail/BlockMarker.java
@@ -2,14 +2,14 @@ package jp.ngt.rtm.rail;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import jp.kaiz.kaizpatch.rtm.rail.TileEntityLargeRailSectionCore;
+import jp.kaiz.kaizpatch.rtm.rail.util.RailChunkSectioner;
+import jp.kaiz.kaizpatch.rtm.rail.util.RailMapSection;
+import jp.kaiz.kaizpatch.rtm.rail.util.RailSection;
 import jp.ngt.ngtlib.io.NGTLog;
 import jp.ngt.ngtlib.math.NGTMath;
 import jp.ngt.ngtlib.math.NGTVec;
 import jp.ngt.ngtlib.util.PermissionManager;
-import jp.kaiz.kaizpatch.rtm.rail.util.RailChunkSectioner;
-import jp.kaiz.kaizpatch.rtm.rail.util.RailMapSection;
-import jp.kaiz.kaizpatch.rtm.rail.util.RailSection;
-import jp.kaiz.kaizpatch.rtm.rail.TileEntityLargeRailSectionCore;
 import jp.ngt.rtm.*;
 import jp.ngt.rtm.item.ItemBlockMarker;
 import jp.ngt.rtm.item.ItemRail;
@@ -234,9 +234,11 @@ public class BlockMarker extends BlockContainer {
         RailMapBasic railMap = new RailMapBasic(start, end, RailMapBasic.fixRTMRailMapVersionCurrent);
 
         if (makeRail && railMap.canPlaceRail(world, isCreative, prop)) {
-            List<RailSection> sections = RailChunkSectioner.split(railMap);
-            if (sections.size() > 1) {
-                return createSectionedRail(world, railMap, sections, prop, isCreative);
+            if (prop.autoSplit) {
+                List<RailSection> sections = RailChunkSectioner.split(railMap);
+                if (sections.size() > 1) {
+                    return createSectionedRail(world, railMap, sections, prop, isCreative);
+                }
             }
             //railMap.setRail(world, RTMRail.largeRailBase[shape[0]], x0, y0, z0);
             railMap.setRail(world, RTMRail.largeRailBase0, start.blockX, start.blockY, start.blockZ, prop);

--- a/src/main/java/jp/ngt/rtm/rail/TileEntityLargeRailBase.java
+++ b/src/main/java/jp/ngt/rtm/rail/TileEntityLargeRailBase.java
@@ -64,7 +64,7 @@ public class TileEntityLargeRailBase extends TileEntityCustom implements ILargeR
     public boolean isTrainOnRail() {
         TileEntityLargeRailCore tile = this.getRailCore();
         if (tile != null) {
-            return tile.isCollidedTrain;
+            return tile.isLogicalRailOccupied();
         }
         return false;
     }

--- a/src/main/java/jp/ngt/rtm/rail/TileEntityLargeRailCore.java
+++ b/src/main/java/jp/ngt/rtm/rail/TileEntityLargeRailCore.java
@@ -157,8 +157,47 @@ public abstract class TileEntityLargeRailCore extends TileEntityLargeRailBase {
         return this.railPositions;
     }
 
+    /**
+     * アイテム化やマーカー復元で利用する、レール全体の端点
+     */
+    public RailPosition[] getLogicalRailPositions() {
+        return this.railPositions;
+    }
+
+    public boolean isSameLogicalRail(TileEntityLargeRailCore other) {
+        return this == other;
+    }
+
+    public boolean isLogicalRailOccupied() {
+        return this.isCollidedTrain;
+    }
+
+    public int getRailRenderMinimumSplit() {
+        return 0;
+    }
+
+    public int getRailRenderEndOffset() {
+        return 0;
+    }
+
+    public boolean shouldRenderRailStartCap() {
+        return true;
+    }
+
+    public boolean shouldRenderRailEndCap() {
+        return true;
+    }
+
+    public void breakLogicalRail() {
+        RailMap[] maps = this.getAllRailMaps();
+        if (maps != null) {
+            Arrays.stream(maps).forEach(rm -> rm.breakRail(this.worldObj, this.getProperty(), this));
+        }
+    }
+
     public void setRailPositions(RailPosition[] par1) {
         this.railPositions = par1;
+        this.railmap = null;
     }
 
     public RailProperty getProperty() {

--- a/src/main/java/jp/ngt/rtm/rail/util/RailMap.java
+++ b/src/main/java/jp/ngt/rtm/rail/util/RailMap.java
@@ -144,10 +144,7 @@ public abstract class RailMap {
      */
     public void setRail(World world, Block block, int x0, int y0, int z0, RailProperty prop) {
         this.createRailList(prop);
-        TileEntity tile = world.getTileEntity(x0, y0, z0);
-        if (tile instanceof TileEntityMarker && ((TileEntityMarker) tile).getState(MarkerState.LINE2)) {
-            this.setBaseBlock(world, x0, y0, z0);
-        }
+        this.prepareBaseBlocks(world, x0, y0, z0);
         this.rails.forEach(rail -> {
             int x = rail[0];
             int y = rail[1];
@@ -163,6 +160,16 @@ public abstract class RailMap {
             }
         });
         this.rails.clear();
+    }
+
+    /**
+     * LINE2マーカーの地形転写だけを先行実行する。
+     */
+    public void prepareBaseBlocks(World world, int x0, int y0, int z0) {
+        TileEntity tile = world.getTileEntity(x0, y0, z0);
+        if (tile instanceof TileEntityMarker && ((TileEntityMarker) tile).getState(MarkerState.LINE2)) {
+            this.setBaseBlock(world, x0, y0, z0);
+        }
     }
 
     private void setBaseBlock(World world, int x0, int y0, int z0) {

--- a/src/main/java/jp/ngt/rtm/rail/util/RailMapBasic.java
+++ b/src/main/java/jp/ngt/rtm/rail/util/RailMapBasic.java
@@ -144,7 +144,12 @@ public class RailMapBasic extends RailMap {
      * @return {z, x}
      */
     public double[] getRailPos(int par1, int par2) {
-        return this.lineHorizontal.getPoint(par1, par2);
+        double ratio = par1 == 0 ? 0.0D : (double) par2 / (double) par1;
+        return this.getRailPos(ratio);
+    }
+
+    public double[] getRailPos(double ratio) {
+        return this.lineHorizontal.getPoint(ratio);
     }
 
     /**
@@ -153,9 +158,14 @@ public class RailMapBasic extends RailMap {
      * @return y
      */
     public double getRailHeight(int par1, int par2) {
+        double ratio = par1 == 0 ? 0.0D : (double) par2 / (double) par1;
+        return this.getRailHeight(ratio);
+    }
+
+    public double getRailHeight(double ratio) {
         float railWidth = 3.0F;//本来はRailConfigから取得すべし
-        double height = this.lineVertical.getPoint(par1, par2)[1];
-        float cant = this.getCant(par1, par2);
+        double height = this.lineVertical.getPoint(ratio)[1];
+        float cant = this.getRailRoll(ratio);
         if (cant != 0.0F) {
             double h2 = Math.abs(NGTMath.sin(cant) * railWidth * 0.5F);
             height += h2;
@@ -167,7 +177,12 @@ public class RailMapBasic extends RailMap {
      * @return 0~360
      */
     public float getRailYaw(int par1, int par2) {
-        return NGTMath.toDegrees((float) this.lineHorizontal.getSlope(par1, par2));
+        double ratio = par1 == 0 ? 0.0D : (double) par2 / (double) par1;
+        return this.getRailYaw(ratio);
+    }
+
+    public float getRailYaw(double ratio) {
+        return NGTMath.toDegrees((float) this.lineHorizontal.getSlope(ratio));
     }
 
     /**
@@ -176,20 +191,30 @@ public class RailMapBasic extends RailMap {
      * @return 0~360
      */
     public float getRailPitch(int par1, int par2) {
-        return NGTMath.toDegrees((float) this.lineVertical.getSlope(par1, par2));
+        double ratio = par1 == 0 ? 0.0D : (double) par2 / (double) par1;
+        return this.getRailPitch(ratio);
+    }
+
+    public float getRailPitch(double ratio) {
+        return NGTMath.toDegrees((float) this.lineVertical.getSlope(ratio));
     }
 
     /**
      * @return カント
      */
     public float getRailRoll(int split, int t) {
-        float ft = 2.0F * t / split;
+        double ratio = split == 0 ? 0.0D : (double) t / (double) split;
+        return this.getRailRoll(ratio);
+    }
+
+    public float getRailRoll(double ratio) {
+        float ft = (float) (2.0D * Math.max(0.0D, Math.min(1.0D, ratio)));
         float c1 = (ft <= 1.0F) ? ((1.0F - ft) * this.startRP.cantEdge) : ((ft - 1.0F) * -this.endRP.cantEdge);
         float c2 = (ft <= 1.0F) ? (ft * this.startRP.cantCenter) : ((2.0F - ft) * this.startRP.cantCenter);
         float cunt = c1 + c2;
         float rand = 0.0F;
         if (this.startRP.cantRandom > 0.0F) {
-            float x = (float) (getLength() * t / split) * this.startRP.cantRandom;
+            float x = (float) (getLength() * ratio) * this.startRP.cantRandom;
             float scale = 3.0F;
             rand = NGTMath.getSin(x) + NGTMath.getSin(x * 0.51F) + NGTMath.getSin(x * 0.252F) + NGTMath.getSin(x * 0.1253F) * 0.25F * scale;
         }

--- a/src/main/java/jp/ngt/rtm/rail/util/RailPosition.java
+++ b/src/main/java/jp/ngt/rtm/rail/util/RailPosition.java
@@ -74,6 +74,15 @@ public class RailPosition {
 
     public double posX, posY, posZ;
 
+    /**
+     * REVISIONおよびマーカー高さから算出した標準位置に対する追加オフセット。
+     * 中間レールのようにブロック端の任意座標を曲線端点として使う場合に使用する。
+     * <p>
+     * なお、ブロックの端であることを保証する責任はRailPositionではなく設定側にあるため、
+     * 適切なバリデーションを行ってください。ブロックは端でない場合、転線が行われないことがあります。
+     */
+    public double offsetX, offsetY, offsetZ;
+
     public RailPosition(int x, int y, int z, byte dir) {
         this(x, y, z, dir, (byte) 0);
     }
@@ -98,14 +107,25 @@ public class RailPosition {
     }
 
     public void init() {
-        this.posX = (double) this.blockX + 0.5D + (double) REVISION[this.direction][0];
-        this.posY = (double) this.blockY + (double) (this.height + 1) * BlockLargeRailBase.THICKNESS;
-        this.posZ = (double) this.blockZ + 0.5D + (double) REVISION[this.direction][1];
+        this.posX = (double) this.blockX + 0.5D + (double) REVISION[this.direction][0] + this.offsetX;
+        this.posY = (double) this.blockY + (double) (this.height + 1) * BlockLargeRailBase.THICKNESS + this.offsetY;
+        this.posZ = (double) this.blockZ + 0.5D + (double) REVISION[this.direction][1] + this.offsetZ;
+    }
+
+    /**
+     * このRailPositionが表す曲線端点をワールド座標で直接指定する。
+     */
+    public void setPosition(double x, double y, double z) {
+        this.offsetX = x - ((double) this.blockX + 0.5D + (double) REVISION[this.direction][0]);
+        this.offsetY = y - ((double) this.blockY + (double) (this.height + 1) * BlockLargeRailBase.THICKNESS);
+        this.offsetZ = z - ((double) this.blockZ + 0.5D + (double) REVISION[this.direction][1]);
+        this.init();
     }
 
     public void addHeight(double par1) {
         int h2 = (int) (par1 / 0.0625D);
         this.height = (byte) (this.height + h2);
+        this.init();
     }
 
     public static RailPosition readFromNBT(NBTTagCompound nbt) {
@@ -126,6 +146,16 @@ public class RailPosition {
         rp.constLimitHN = nbt.getFloat("Const_Limit_HN");
         rp.constLimitWP = nbt.getFloat("Const_Limit_WP");
         rp.constLimitWN = nbt.getFloat("Const_Limit_WN");
+        if (nbt.hasKey("OffsetX")) {
+            rp.offsetX = nbt.getDouble("OffsetX");
+        }
+        if (nbt.hasKey("OffsetY")) {
+            rp.offsetY = nbt.getDouble("OffsetY");
+        }
+        if (nbt.hasKey("OffsetZ")) {
+            rp.offsetZ = nbt.getDouble("OffsetZ");
+        }
+        rp.init();
         return rp;
     }
 
@@ -147,13 +177,23 @@ public class RailPosition {
         nbt.setFloat("Const_Limit_WP", this.constLimitWP);
         nbt.setFloat("Const_Limit_WN", this.constLimitWN);
 
+        if (this.offsetX != 0.0D) {
+            nbt.setDouble("OffsetX", this.offsetX);
+        }
+        if (this.offsetY != 0.0D) {
+            nbt.setDouble("OffsetY", this.offsetY);
+        }
+        if (this.offsetZ != 0.0D) {
+            nbt.setDouble("OffsetZ", this.offsetZ);
+        }
+
         nbt.setByte("SwitchType", this.switchType);
         return nbt;
     }
 
     public void setHeight(byte par1) {
         this.height = par1;
-        this.posY = (double) this.blockY + (double) (par1 + 1) * 0.0625D;
+        this.init();
     }
 
     /**

--- a/src/main/java/jp/ngt/rtm/rail/util/RailProperty.java
+++ b/src/main/java/jp/ngt/rtm/rail/util/RailProperty.java
@@ -13,15 +13,21 @@ public final class RailProperty {
     public final Block block;
     public final int blockMetadata;
     public final float blockHeight;
+    public final boolean autoSplit;
     public final String unlocalizedName;
 
     private ModelSetRail modelSet;
 
     public RailProperty(String par1, Block par2, int par3, float par4) {
+        this(par1, par2, par3, par4, true);
+    }
+
+    public RailProperty(String par1, Block par2, int par3, float par4, boolean autoSplit) {
         this.railModel = par1;
         this.block = par2;
         this.blockMetadata = par3;
         this.blockHeight = (par4 <= 0.0F) ? 0.0625F : par4;
+        this.autoSplit = autoSplit;
 
         Item item = Item.getItemFromBlock(par2);
         //空気ブロックとかでnull
@@ -38,7 +44,12 @@ public final class RailProperty {
         }
         int i0 = nbt.getInteger("BlockMetadata");
         float b0 = nbt.getFloat("BlockHeight");
-        return new RailProperty(s0, block, i0, b0);
+        boolean autoSplit = readAutoSplit(nbt);
+        return new RailProperty(s0, block, i0, b0, autoSplit);
+    }
+
+    static boolean readAutoSplit(NBTTagCompound nbt) {
+        return !nbt.hasKey("AutoSplit") || nbt.getBoolean("AutoSplit");
     }
 
     public void writeToNBT(NBTTagCompound nbt) {
@@ -47,6 +58,7 @@ public final class RailProperty {
         nbt.setString("BlockName", s1);
         nbt.setInteger("BlockMetadata", this.blockMetadata);
         nbt.setFloat("BlockHeight", this.blockHeight);
+        nbt.setBoolean("AutoSplit", this.autoSplit);
     }
 
     public ModelSetRail getModelSet() {

--- a/src/main/java/jp/ngt/rtm/render/DynamicRailPartsRenderer.java
+++ b/src/main/java/jp/ngt/rtm/render/DynamicRailPartsRenderer.java
@@ -137,11 +137,10 @@ public class DynamicRailPartsRenderer extends RailPartsRenderer {
         int endIndex = par3 ? halfMax : max;
 
         double[] origPos = rms.getRailPos(max, 0);
-        int[] startPos = tileEntity.getStartPoint();
-        float[] revXZ = RailPosition.REVISION[tileEntity.getRailPositions()[0].direction];
+        RailPosition originRP = tileEntity.getRailPositions()[0];
         //レール全体の始点からの移動差分
-        float moveX = (float) (origPos[1] - ((double) startPos[0] + 0.5D + (double) revXZ[0]));
-        float moveZ = (float) (origPos[0] - ((double) startPos[2] + 0.5D + (double) revXZ[1]));
+        float moveX = (float) (origPos[1] - originRP.posX);
+        float moveZ = (float) (origPos[0] - originRP.posZ);
         //向きによって移動量を反転させる
         float dirFixture = ((par3 && dir == RailDir.LEFT) || (!par3 && dir == RailDir.RIGHT)) ? -1.0F : 1.0F;
 

--- a/src/main/java/jp/ngt/rtm/render/RailPartsRenderer.java
+++ b/src/main/java/jp/ngt/rtm/render/RailPartsRenderer.java
@@ -23,10 +23,10 @@ import java.nio.FloatBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.stream.IntStream;
 
 @SideOnly(Side.CLIENT)
 public class RailPartsRenderer extends TileEntityPartsRenderer<ModelSetRailClient> {
+    private static final int BRIGHTNESS_PENDING_RENDER_KEY = Integer.MIN_VALUE;
     protected int currentRailIndex;
     private final FloatBuffer convBuf;
     private boolean isCompilingStaticRail;
@@ -65,11 +65,18 @@ public class RailPartsRenderer extends TileEntityPartsRenderer<ModelSetRailClien
      */
     protected void renderRailStatic(TileEntityLargeRailCore tileEntity, double x, double y, double z, float par8) {
         boolean hasGLList = this.prepareStaticDisplayList(tileEntity);
-        if (hasGLList && tileEntity.shouldRerenderRail && !this.shouldRefreshDisplayList(tileEntity)) {
-            tileEntity.shouldRerenderRail = false;
+        boolean brightnessReady = true;
+        boolean refreshRequested = tileEntity.shouldRerenderRail
+                || tileEntity.getStaticRenderKey(this.currentRailIndex) == BRIGHTNESS_PENDING_RENDER_KEY;
+        if (hasGLList && refreshRequested) {
+            brightnessReady = this.areRailBrightnessPositionsLoaded(tileEntity);
+            if (brightnessReady && !this.shouldRefreshDisplayList(tileEntity)) {
+                tileEntity.shouldRerenderRail = false;
+                refreshRequested = false;
+            }
         }
 
-        if (!hasGLList || tileEntity.shouldRerenderRail) {
+        if (!hasGLList || (refreshRequested && brightnessReady)) {
             this.compileStaticRailParts(tileEntity, x, y, z, par8);
             hasGLList = GLHelper.isValid(tileEntity.glLists[this.currentRailIndex]);
         }
@@ -110,11 +117,18 @@ public class RailPartsRenderer extends TileEntityPartsRenderer<ModelSetRailClien
         }
 
         boolean hasGLList = this.prepareStaticDisplayList(tileEntity);
-        if (hasGLList && tileEntity.shouldRerenderRail && !this.shouldRefreshDisplayList(tileEntity)) {
-            tileEntity.shouldRerenderRail = false;
+        boolean brightnessReady = true;
+        boolean refreshRequested = tileEntity.shouldRerenderRail
+                || tileEntity.getStaticRenderKey(this.currentRailIndex) == BRIGHTNESS_PENDING_RENDER_KEY;
+        if (hasGLList && refreshRequested) {
+            brightnessReady = this.areRailBrightnessPositionsLoaded(tileEntity);
+            if (brightnessReady && !this.shouldRefreshDisplayList(tileEntity)) {
+                tileEntity.shouldRerenderRail = false;
+                refreshRequested = false;
+            }
         }
 
-        if (!hasGLList || tileEntity.shouldRerenderRail) {
+        if (!hasGLList || (refreshRequested && brightnessReady)) {
             GLHelper.startCompile(tileEntity.glLists[this.currentRailIndex]);//GL_COMPILE_AND_EXECUTEは画面がチラつく
             try {
                 hasGLList = this.renderStaticPartsGeometry(tileEntity);
@@ -171,11 +185,13 @@ public class RailPartsRenderer extends TileEntityPartsRenderer<ModelSetRailClien
     private boolean renderStaticPartsGeometry(TileEntityLargeRailCore tileEntity) {
         this.renderedStaticGeometry = true;
         float[][] fa = this.createRailPos(tileEntity);
-        if (fa == null || fa.length <= 1) {
+        if (fa == null || fa.length == 0 || (fa.length == 1 && tileEntity.getRailRenderMinimumSplit() == 0)) {
             tileEntity.shouldRerenderRail = true;
             return false;
         }
 
+        boolean brightnessReady = this.areRailBrightnessPositionsLoaded(
+                tileEntity.getWorldObj(), tileEntity.xCoord, tileEntity.yCoord, tileEntity.zCoord, fa);
         int[] brightness = this.getRailBrightness(tileEntity.getWorldObj(), tileEntity.xCoord, tileEntity.yCoord, tileEntity.zCoord, fa);
         FloatBuffer fb = this.createMatrix(fa);
         List<GroupObject> groups = this.modelSet.model.model.getGroupObjects();
@@ -183,9 +199,12 @@ public class RailPartsRenderer extends TileEntityPartsRenderer<ModelSetRailClien
             tileEntity.shouldRerenderRail = true;
             return false;
         }
-        tileEntity.setStaticRenderKey(this.currentRailIndex, this.createStaticRenderKey(fa, brightness));
+        int renderKey = brightnessReady
+                ? this.createStaticRenderKey(fa, brightness)
+                : BRIGHTNESS_PENDING_RENDER_KEY;
+        tileEntity.setStaticRenderKey(this.currentRailIndex, renderKey);
         this.tessellateParts(tileEntity, fb, brightness, groups);
-        tileEntity.shouldRerenderRail = false;
+        tileEntity.shouldRerenderRail = !brightnessReady;
         return true;
     }
 
@@ -195,7 +214,7 @@ public class RailPartsRenderer extends TileEntityPartsRenderer<ModelSetRailClien
         }
 
         float[][] fa = this.createRailPos(tileEntity);
-        if (fa == null || fa.length <= 1) {
+        if (fa == null || fa.length == 0 || (fa.length == 1 && tileEntity.getRailRenderMinimumSplit() == 0)) {
             return true;
         }
 
@@ -246,21 +265,23 @@ public class RailPartsRenderer extends TileEntityPartsRenderer<ModelSetRailClien
      * @return {x, y, z, yaw, pitch, roll}
      */
     protected float[][] createRailPos(TileEntityLargeRailCore par1) {
-        float[] rev = RailPosition.REVISION[par1.getRailPositions()[0].direction];
+        RailPosition originRP = par1.getRailPositions()[0];
         RailMap[] rms = par1.getAllRailMaps();
         if (rms != null) {
             List<float[]> list = new ArrayList<>();
             for (RailMap rm : rms) {
                 int max = (int) ((float) rm.getLength() * 2.0F);
+                max = Math.max(max, par1.getRailRenderMinimumSplit());
                 double[] stPoint = rm.getRailPos(max, 0);
                 //double startH = rm.getRailHeight(max, 0);//カント付けた時端が沈む
                 double startH = rm.getStartRP().posY;
-                float moveX = (float) (stPoint[1] - ((double) par1.getStartPoint()[0] + 0.5D + (double) rev[0]));
-                float moveZ = (float) (stPoint[0] - ((double) par1.getStartPoint()[2] + 0.5D + (double) rev[1]));
+                float moveX = (float) (stPoint[1] - originRP.posX);
+                float moveZ = (float) (stPoint[0] - originRP.posZ);
                 //RM未初期化状態でのリスト生成を防止
                 //if(moveX == 0.0F && moveZ == 0.0F){return null;}
 
-                for (int i = 0; i < max + 1; ++i) {
+                int endIndex = Math.max(0, max - par1.getRailRenderEndOffset());
+                for (int i = 0; i <= endIndex; ++i) {
                     double[] curPoint = rm.getRailPos(max, i);
                     float[] array = {
                             moveX + (float) (curPoint[1] - stPoint[1]),
@@ -301,14 +322,52 @@ public class RailPartsRenderer extends TileEntityPartsRenderer<ModelSetRailClien
      * レール上の明るさを一括取得
      */
     protected final int[] getRailBrightness(World world, int x, int y, int z, float[][] rp) {
-        int[] fa = new int[rp.length];
-        IntStream.range(0, rp.length).forEach(i -> {
+        final int unavailable = Integer.MIN_VALUE;
+        int[] brightness = new int[rp.length];
+        int fallback = this.getBrightness(world, x, y, z);
+        int previous = unavailable;
+        for (int i = 0; i < rp.length; ++i) {
             int x0 = x + MathHelper.floor_double(rp[i][0]);
             int y0 = y + MathHelper.floor_double(rp[i][1]);
             int z0 = z + MathHelper.floor_double(rp[i][2]);
-            fa[i] = this.getBrightness(world, x0, y0, z0);
-        });
-        return fa;
+            if (world.blockExists(x0, y0, z0)) {
+                brightness[i] = this.getBrightness(world, x0, y0, z0);
+                previous = brightness[i];
+                fallback = brightness[i];
+            } else if (previous != unavailable) {
+                brightness[i] = previous;
+            } else {
+                brightness[i] = unavailable;
+            }
+        }
+
+        int next = fallback;
+        for (int i = brightness.length - 1; i >= 0; --i) {
+            if (brightness[i] == unavailable) {
+                brightness[i] = next;
+            } else {
+                next = brightness[i];
+            }
+        }
+        return brightness;
+    }
+
+    private boolean areRailBrightnessPositionsLoaded(TileEntityLargeRailCore tileEntity) {
+        float[][] positions = this.createRailPos(tileEntity);
+        return positions != null && this.areRailBrightnessPositionsLoaded(
+                tileEntity.getWorldObj(), tileEntity.xCoord, tileEntity.yCoord, tileEntity.zCoord, positions);
+    }
+
+    private boolean areRailBrightnessPositionsLoaded(World world, int x, int y, int z, float[][] positions) {
+        for (float[] position : positions) {
+            int x0 = x + MathHelper.floor_double(position[0]);
+            int y0 = y + MathHelper.floor_double(position[1]);
+            int z0 = z + MathHelper.floor_double(position[2]);
+            if (!world.blockExists(x0, y0, z0)) {
+                return false;
+            }
+        }
+        return true;
     }
 
     /**
@@ -344,9 +403,13 @@ public class RailPartsRenderer extends TileEntityPartsRenderer<ModelSetRailClien
         for (int i = 0; i < capacity; ++i) {
             tessellator.setBrightness(brightness[i]);
             for (GroupObject group : gObjList) {
-                if (group.name.startsWith("side") && !(i == 0 || i == capacity - 1)) {
-                    continue;
-                }//レールの端以外は断面を描画しない, +1~2fps
+                if (group.name.startsWith("side")) {
+                    boolean isStartCap = i == 0 && tileEntity.shouldRenderRailStartCap();
+                    boolean isEndCap = i == capacity - 1 && tileEntity.shouldRenderRailEndCap();
+                    if (!isStartCap && !isEndCap) {
+                        continue;
+                    }
+                }//レール全体の端以外は断面を描画しない, +1~2fps
 
                 if (!this.shouldRenderObject(tileEntity, group.name, capacity, i)) {
                     continue;
@@ -373,11 +436,10 @@ public class RailPartsRenderer extends TileEntityPartsRenderer<ModelSetRailClien
     public void renderRailMapStatic(TileEntityLargeRailSwitchCore tileEntity, RailMap rm, int max, int startIndex, int endIndex, Parts... pArray) {
         double[] origPos = rm.getRailPos(max, 0);
         double origHeight = rm.getRailHeight(max, 0);
-        int[] startPos = tileEntity.getStartPoint();
-        float[] revXZ = RailPosition.REVISION[tileEntity.getRailPositions()[0].direction];
+        RailPosition originRP = tileEntity.getRailPositions()[0];
         //レール全体の始点からの移動差分
-        float moveX = (float) (origPos[1] - ((double) startPos[0] + 0.5D + (double) revXZ[0]));
-        float moveZ = (float) (origPos[0] - ((double) startPos[2] + 0.5D + (double) revXZ[1]));
+        float moveX = (float) (origPos[1] - originRP.posX);
+        float moveZ = (float) (origPos[0] - originRP.posZ);
 
         //頂点-中間点
         for (int i = startIndex; i <= endIndex; i++) {

--- a/src/test/kotlin/jp/kaiz/kaizpatch/rtm/rail/util/RailChunkSectionerTest.kt
+++ b/src/test/kotlin/jp/kaiz/kaizpatch/rtm/rail/util/RailChunkSectionerTest.kt
@@ -1,0 +1,146 @@
+package jp.kaiz.kaizpatch.rtm.rail.util
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.doubles.plusOrMinus
+import io.kotest.matchers.shouldBe
+import jp.ngt.rtm.rail.util.RailMapBasic
+import jp.ngt.rtm.rail.util.RailPosition
+import kotlin.math.floor
+
+class RailChunkSectionerTest : FunSpec({
+    test("rail inside one chunk is not sectioned") {
+        val map = straightRail(0, 10)
+
+        val sections = RailChunkSectioner.split(map)
+
+        sections.size shouldBe 1
+        sections.single().startRatio shouldBe 0.0
+        sections.single().endRatio shouldBe 1.0
+    }
+
+    test("straight rail creates one section per traversed chunk") {
+        val map = straightRail(0, 40)
+
+        val sections = RailChunkSectioner.split(map)
+
+        sections.size shouldBe 3
+        sections.map { it.startRP.blockX shr 4 } shouldBe listOf(0, 1, 2)
+        assertContinuous(map, sections)
+    }
+
+    test("negative coordinates use Minecraft chunk flooring") {
+        val map = straightRail(-40, 0)
+
+        val sections = RailChunkSectioner.split(map)
+
+        (sections.size >= 3) shouldBe true
+        (sections.first().startRP.blockX shr 4) shouldBe -3
+        (sections.last().startRP.blockX shr 4) shouldBe 0
+        assertContinuous(map, sections)
+    }
+
+    test("diagonal corner crossing produces one boundary") {
+        val map = RailMapBasic(
+            RailPosition(0, 64, 0, 1),
+            RailPosition(31, 64, 31, 5),
+            RailMapBasic.fixRTMRailMapVersionCurrent,
+        )
+
+        val sections = RailChunkSectioner.split(map)
+
+        sections.size shouldBe 2
+        (sections[0].startRP.blockX shr 4) shouldBe 0
+        (sections[0].startRP.blockZ shr 4) shouldBe 0
+        (sections[1].startRP.blockX shr 4) shouldBe 1
+        (sections[1].startRP.blockZ shr 4) shouldBe 1
+        assertContinuous(map, sections)
+    }
+
+    test("sloped section keeps exact boundary height in offset") {
+        val start = RailPosition(0, 64, 0, 2)
+        val end = RailPosition(40, 72, 0, 6)
+        val map = RailMapBasic(start, end, RailMapBasic.fixRTMRailMapVersionCurrent)
+
+        val sections = RailChunkSectioner.split(map)
+
+        (sections.size > 1) shouldBe true
+        sections.drop(1).forEach { section ->
+            section.startRP.posY shouldBe (map.getRailHeight(section.startRatio) plusOrMinus 1.0E-7)
+            (section.startRP.offsetY != 0.0 || section.startRP.posY % 0.0625 == 0.0) shouldBe true
+        }
+        assertContinuous(map, sections)
+    }
+
+    test("curved sections delegate position, yaw, pitch, and cant to source") {
+        val start = RailPosition(0, 64, 0, 2).apply {
+            anchorYaw = 35.0F
+            anchorPitch = 4.0F
+            anchorLengthHorizontal = 18.0F
+            anchorLengthVertical = 12.0F
+            cantEdge = 1.5F
+            cantCenter = 4.0F
+            cantRandom = 0.2F
+        }
+        val end = RailPosition(40, 68, 24, 6).apply {
+            anchorYaw = -120.0F
+            anchorPitch = -3.0F
+            anchorLengthHorizontal = 16.0F
+            anchorLengthVertical = 10.0F
+            cantEdge = -2.0F
+        }
+        val source = RailMapBasic(start, end, RailMapBasic.fixRTMRailMapVersionCurrent)
+        val sections = RailChunkSectioner.split(source)
+
+        (sections.size > 1) shouldBe true
+        sections.forEach { section ->
+            val map = RailMapSection(source, section.startRP, section.endRP, section.startRatio, section.endRatio)
+            val localRatio = 0.37
+            val sourceRatio = map.sourceRatio(localRatio)
+            val split = 1000
+            val index = (localRatio * split).toInt()
+            val expected = source.getRailPos(sourceRatio)
+            val actual = map.getRailPos(split, index)
+            actual[0] shouldBe (expected[0] plusOrMinus 1.0E-7)
+            actual[1] shouldBe (expected[1] plusOrMinus 1.0E-7)
+            map.getRailHeight(split, index) shouldBe (source.getRailHeight(sourceRatio) plusOrMinus 1.0E-7)
+            map.getRailYaw(split, index).toDouble() shouldBe
+                    (source.getRailYaw(sourceRatio).toDouble() plusOrMinus 1.0E-5)
+            map.getRailPitch(split, index).toDouble() shouldBe
+                    (source.getRailPitch(sourceRatio).toDouble() plusOrMinus 1.0E-5)
+            map.getRailRoll(split, index).toDouble() shouldBe
+                    (source.getRailRoll(sourceRatio).toDouble() plusOrMinus 1.0E-5)
+        }
+        assertContinuous(source, sections)
+    }
+})
+
+private fun straightRail(startX: Int, endX: Int): RailMapBasic {
+    return RailMapBasic(
+        RailPosition(startX, 64, 0, 2),
+        RailPosition(endX, 64, 0, 6),
+        RailMapBasic.fixRTMRailMapVersionCurrent,
+    )
+}
+
+private fun assertContinuous(source: RailMapBasic, sections: List<RailSection>) {
+    sections.forEachIndexed { index, section ->
+        val sectionMap = RailMapSection(source, section.startRP, section.endRP, section.startRatio, section.endRatio)
+        val start = sectionMap.getRailPos(100, 0)
+        val end = sectionMap.getRailPos(100, 100)
+        val expectedStart = source.getRailPos(section.startRatio)
+        val expectedEnd = source.getRailPos(section.endRatio)
+        start[0] shouldBe (expectedStart[0] plusOrMinus 1.0E-7)
+        start[1] shouldBe (expectedStart[1] plusOrMinus 1.0E-7)
+        end[0] shouldBe (expectedEnd[0] plusOrMinus 1.0E-7)
+        end[1] shouldBe (expectedEnd[1] plusOrMinus 1.0E-7)
+        if (index + 1 < sections.size) {
+            sections[index + 1].startRatio shouldBe (section.endRatio plusOrMinus 1.0E-12)
+            sections[index + 1].startRP.posX shouldBe (section.endRP.posX plusOrMinus 1.0E-7)
+            sections[index + 1].startRP.posY shouldBe (section.endRP.posY plusOrMinus 1.0E-7)
+            sections[index + 1].startRP.posZ shouldBe (section.endRP.posZ plusOrMinus 1.0E-7)
+            floor(sections[index + 1].startRP.posX) shouldBe floor(section.endRP.posX)
+            section.endRP.direction.toInt() shouldBe
+                    ((sections[index + 1].startRP.direction.toInt() + 4) and 7)
+        }
+    }
+}

--- a/src/test/kotlin/jp/kaiz/kaizpatch/rtm/rail/util/RailPositionOffsetTest.kt
+++ b/src/test/kotlin/jp/kaiz/kaizpatch/rtm/rail/util/RailPositionOffsetTest.kt
@@ -1,0 +1,71 @@
+package jp.kaiz.kaizpatch.rtm.rail.util
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.doubles.plusOrMinus
+import io.kotest.matchers.shouldBe
+import jp.ngt.rtm.rail.util.RailPosition
+import net.minecraft.nbt.NBTTagCompound
+
+class RailPositionOffsetTest : FunSpec({
+    test("legacy position is unchanged without offset tags") {
+        val legacy = NBTTagCompound().apply {
+            setIntArray("BlockPos", intArrayOf(10, 64, -5))
+            setByte("Direction", 2)
+            setByte("SwitchType", 0)
+            setByte("Height", 3)
+        }
+
+        val position = RailPosition.readFromNBT(legacy)
+
+        position.posX shouldBe 10.0
+        position.posY shouldBe 64.25
+        position.posZ shouldBe -4.5
+        position.offsetX shouldBe 0.0
+        position.offsetY shouldBe 0.0
+        position.offsetZ shouldBe 0.0
+    }
+
+    test("arbitrary world position round-trips through NBT") {
+        val position = RailPosition(15, 70, -17, 6)
+        position.setPosition(16.0, 70.375, -16.25)
+
+        val saved = position.writeToNBT()
+        val restored = RailPosition.readFromNBT(saved)
+
+        restored.posX shouldBe (16.0 plusOrMinus 1.0E-12)
+        restored.posY shouldBe (70.375 plusOrMinus 1.0E-12)
+        restored.posZ shouldBe (-16.25 plusOrMinus 1.0E-12)
+        (restored.offsetX == 0.0 && restored.offsetY == 0.0 && restored.offsetZ == 0.0) shouldBe false
+    }
+
+    test("moving position keeps its relative offset") {
+        val position = RailPosition(15, 70, 0, 6)
+        position.setPosition(16.0, 70.2, 0.75)
+        val offset = doubleArrayOf(position.offsetX, position.offsetY, position.offsetZ)
+
+        position.movePos(-32, 4, 16)
+
+        position.posX shouldBe (-16.0 plusOrMinus 1.0E-12)
+        position.posY shouldBe (74.2 plusOrMinus 1.0E-12)
+        position.posZ shouldBe (16.75 plusOrMinus 1.0E-12)
+        position.offsetX shouldBe offset[0]
+        position.offsetY shouldBe offset[1]
+        position.offsetZ shouldBe offset[2]
+    }
+
+    test("height changes keep offsets and refresh world position") {
+        val position = RailPosition(3, 64, 7, 0)
+        position.setPosition(3.75, 64.4, 7.25)
+        val offsets = doubleArrayOf(position.offsetX, position.offsetY, position.offsetZ)
+
+        position.setHeight(4)
+        position.offsetX shouldBe offsets[0]
+        position.offsetY shouldBe offsets[1]
+        position.offsetZ shouldBe offsets[2]
+        position.posY shouldBe (64.65 plusOrMinus 1.0E-12)
+
+        position.addHeight(0.125)
+        position.offsetY shouldBe offsets[1]
+        position.posY shouldBe (64.775 plusOrMinus 1.0E-12)
+    }
+})


### PR DESCRIPTION
チャンクを跨ぐ通常レールを分割して描画するようにする, RailPositionにoffsetを設定できるようにする
closes: #189, #44 , #415 

- 新規レール敷設時に複数のTileEntityLargeRailSectionCoreを置き、RailMapをProxyするRailMapSectionによる管理を行う
  - つまり、チャンクを跨ぐレールには2つ以上のTileEntityLargeRailSectionCoreが含まれるようになる
  - 構造としてはRailCoreを継承するSecitonCoreが存在するのみであるため、WebCTCのようなinstanceofでRailCoreを判定する物に支障は無い
  - 間ではジョイント音がしないためロングレールが作れるようになりうれしい
- SRBのような外部ツール向けにRailPosition offsetを追加
  - 直接点を指定し、オフセットをRailPositionの責で計算する
- マーカーに数値を手動で設定する卓越した利用者向けの機能は要検討